### PR TITLE
Nmctheme registration without server change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 node_modules/
 /.php_cs.cache
+/.php-cs-fixer.cache
 /lib/Vendor
 tests/.phpunit.result.cache
 /vendor-bin/mozart/vendor

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+require_once './vendor/autoload.php';
+
+use Nextcloud\CodingStandard\Config;
+
+$config = new Config();
+$config
+    ->getFinder()
+    ->notPath('build')
+    ->notPath('node_modules')
+    ->notPath('l10n')
+    ->notPath('src')
+    ->notPath('vendor')
+    ->notPath('lib/Vendor')
+    ->in(__DIR__);
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,42 @@
 {
   "name": "nextmcloud/nmctheme",
   "description": "MagentaCLOUD theme for NC25 ff.",
+  "type": "project",
   "license": "AGPL3",
-  "config": {
-    "optimize-autoloader": true,
-    "classmap-authoritative": true
-  },
-  "scripts": {
-    "cs:fix": "php-cs-fixer fix",
-    "cs:check": "php-cs-fixer fix --dry-run --diff",
-    "lint": "find . -name \\*.php -not -path './vendor/*' -exec php -l \"{}\" \\;",
-    "test:unit": "phpunit -c tests/phpunit.xml",
-    "post-install-cmd": [
-      "@composer bin all install --ansi",
-      "composer dump-autoload"
-    ],
-    "post-update-cmd": [
-      "@composer bin all install --ansi",
-      "composer dump-autoload"
-    ]
-  },
+  "authors": [
+    {
+        "name": "B. Rederlechner",
+        "email": "bernd.rederlechner@t-systems.com"
+    }
+  ],
   "require": {
     "php": "^8.0"
   },
   "require-dev": {
-    "nextcloud/coding-standard": "^0.5.0"
+    "roave/security-advisories": "dev-master",
+    "nextcloud/coding-standard": "^1.0.0",
+    "psalm/phar": "^5.4",
+    "phpunit/phpunit": "^9.5",
+    "ext-mbstring": "*",
+    "nextcloud/ocp": "dev-master"
   },
-  "extra": {
+  "config": {
+    "optimize-autoloader": true,
+    "classmap-authoritative": true,
+    "platform": {
+        "php": "8.0"
+    }
+  },
+  "scripts": {
+    "lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",
+    "cs:check": "php-cs-fixer fix --dry-run --diff",
+    "cs:fix": "php-cs-fixer fix",
+    "psalm": "psalm.phar",
+    "test:unit": "phpunit -c tests/phpunit.xml"
+  },
+  "autoload-dev": {
+    "psr-4": {
+        "OCP\\": "vendor/nextcloud/ocp/OCP"
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,262 +4,40 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bfc5f4d60d6af22617a0745b81b8439",
+    "content-hash": "4e5c7b7d261f51a99413213f97087e66",
     "packages": [],
     "packages-dev": [
         {
-            "name": "composer/pcre",
-            "version": "1.0.1",
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.3",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Pcre\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
-            "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-21T20:24:37+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-04-01T19:23:25+00:00"
-        },
-        {
-            "name": "composer/xdebug-handler",
-            "version": "2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/9e36aeed4616366d2b690bdce11f71e9178c579a",
-                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a",
-                "shasum": ""
-            },
-            "require": {
-                "composer/pcre": "^1",
-                "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Composer\\XdebugHandler\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "John Stevenson",
-                    "email": "john-stevenson@blueyonder.co.uk"
-                }
-            ],
-            "description": "Restarts a process without Xdebug.",
-            "keywords": [
-                "Xdebug",
-                "performance"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-02-24T20:20:32+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "1.14.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "fb0d71a7393298a7b232cbf4c8b1f73f3ec3d5af"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/fb0d71a7393298a7b232cbf4c8b1f73f3ec3d5af",
-                "reference": "fb0d71a7393298a7b232cbf4c8b1f73f3ec3d5af",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^1 || ^2",
-                "ext-tokenizer": "*",
-                "php": "^7.1 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "~1.4.10 || ^1.8.0",
+                "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^4.4 || ^5.4 || ^6",
-                "vimeo/psalm": "^4.10"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -268,147 +46,20 @@
             ],
             "authors": [
                 {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
+                "constructor",
+                "instantiate"
             ],
             "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.14.3"
-            },
-            "time": "2023-02-01T09:20:38+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
-            },
-            "time": "2023-06-03T09:27:29+00:00"
-        },
-        {
-            "name": "doctrine/lexer",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "lexer",
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -420,138 +71,88 @@
                     "type": "patreon"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
-            "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.19.3",
+            "name": "myclabs/deep-copy",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
-                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.2 || ^2.0",
-                "doctrine/annotations": "^1.2",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
-                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
-                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
-                "symfony/polyfill-php70": "^1.0",
-                "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0 || ^5.0",
-                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.4",
-                "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.4.2",
-                "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-                "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.5",
-                "phpunitgoodpractices/polyfill": "^1.5",
-                "phpunitgoodpractices/traits": "^1.9.1",
-                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
-                "symfony/phpunit-bridge": "^5.2.1",
-                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
-            "suggest": {
-                "ext-dom": "For handling output formats in XML",
-                "ext-mbstring": "For handling non-UTF8 characters.",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
-                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
-            },
-            "bin": [
-                "php-cs-fixer"
-            ],
-            "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.19-dev"
-                }
-            },
+            "type": "library",
             "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
                 "psr-4": {
-                    "PhpCsFixer\\": "src/"
-                },
-                "classmap": [
-                    "tests/Test/AbstractFixerTestCase.php",
-                    "tests/Test/AbstractIntegrationCaseFactory.php",
-                    "tests/Test/AbstractIntegrationTestCase.php",
-                    "tests/Test/Assert/AssertTokensTrait.php",
-                    "tests/Test/IntegrationCase.php",
-                    "tests/Test/IntegrationCaseFactory.php",
-                    "tests/Test/IntegrationCaseFactoryInterface.php",
-                    "tests/Test/InternalIntegrationCaseFactory.php",
-                    "tests/Test/IsIdenticalConstraint.php",
-                    "tests/Test/TokensWithObservedTransformers.php",
-                    "tests/TestCase.php"
-                ]
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Dariusz Rumiński",
-                    "email": "dariusz.ruminski@gmail.com"
-                }
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
             ],
-            "description": "A tool to automatically fix PHP code style",
             "support": {
-                "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.19.3"
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
-                    "url": "https://github.com/keradus",
-                    "type": "github"
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-11-15T17:17:55+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "v0.5.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
-                "reference": "742ed895ae76c10daf95e08488cfb3f554199f40"
+                "reference": "55def702fb9a37a219511e1d8c6fe8e37164c1fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/742ed895ae76c10daf95e08488cfb3f554199f40",
-                "reference": "742ed895ae76c10daf95e08488cfb3f554199f40",
+                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/55def702fb9a37a219511e1d8c6fe8e37164c1fb",
+                "reference": "55def702fb9a37a219511e1d8c6fe8e37164c1fb",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.17",
-                "php": "^7.2|^8.0"
+                "php": "^7.3|^8.0",
+                "php-cs-fixer/shim": "^3.17"
             },
             "type": "library",
             "autoload": {
@@ -572,30 +173,187 @@
             "description": "Nextcloud coding standards for the php cs fixer",
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/v0.5.0"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.1.1"
             },
-            "time": "2021-01-11T14:15:58+00:00"
+            "time": "2023-06-01T12:05:01+00:00"
         },
         {
-            "name": "php-cs-fixer/diff",
-            "version": "v1.3.1",
+            "name": "nextcloud/ocp",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759"
+                "url": "https://github.com/nextcloud-deps/ocp.git",
+                "reference": "38874f622280f82c99db0c49b0bb7f62219407eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/dbd31aeb251639ac0b9e7e29405c1441907f5759",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/38874f622280f82c99db0c49b0bb7f62219407eb",
+                "reference": "38874f622280f82c99db0c49b0bb7f62219407eb",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
+                "php": "~8.0 || ~8.1 || ~8.2",
+                "psr/clock": "^1.0",
+                "psr/container": "^2.0.2",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.1.4"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "28.0.0-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Wurst",
+                    "email": "christoph@winzerhof-wurst.at"
+                }
+            ],
+            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
+            "support": {
+                "issues": "https://github.com/nextcloud-deps/ocp/issues",
+                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+            },
+            "time": "2023-07-28T00:36:16+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
-                "symfony/process": "^3.3"
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+            },
+            "time": "2023-06-25T14:52:30+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -609,55 +367,558 @@
             ],
             "authors": [
                 {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "SpacePossum"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "sebastian/diff v2 backport support for PHP5.6",
-            "homepage": "https://github.com/PHP-CS-Fixer",
-            "keywords": [
-                "diff"
-            ],
+            "description": "Library for handling version information and constraints",
             "support": {
-                "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
-                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "abandoned": true,
-            "time": "2020-10-14T08:39:05+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "psr/cache",
-            "version": "3.0.0",
+            "name": "php-cs-fixer/shim",
+            "version": "v3.22.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+                "url": "https://github.com/PHP-CS-Fixer/shim.git",
+                "reference": "f6692934a6d1fe40fd8bc3339487490baa4a6700"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/f6692934a6d1fe40fd8bc3339487490baa4a6700",
+                "reference": "f6692934a6d1fe40fd8bc3339487490baa4a6700",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "replace": {
+                "friendsofphp/php-cs-fixer": "self.version"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer",
+                "php-cs-fixer.phar"
+            ],
+            "type": "application",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.22.0"
+            },
+            "time": "2023-07-16T23:08:49+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.15",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-07-26T13:44:30+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.5",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.2",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-10T04:04:23+00:00"
+        },
+        {
+            "name": "psalm/phar",
+            "version": "5.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/phar.git",
+                "reference": "2107e3e98b25b93cb366dc601d1190af102431a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/2107e3e98b25b93cb366dc601d1190af102431a5",
+                "reference": "2107e3e98b25b93cb366dc601d1190af102431a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "vimeo/psalm": "*"
+            },
+            "bin": [
+                "psalm.phar"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer-based Psalm Phar",
+            "support": {
+                "issues": "https://github.com/psalm/phar/issues",
+                "source": "https://github.com/psalm/phar/tree/5.13.1"
+            },
+            "time": "2023-06-27T17:20:37+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
                 "psr-4": {
-                    "Psr\\Cache\\": "src/"
+                    "Psr\\Clock\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -670,16 +931,20 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interface for caching libraries",
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
             "keywords": [
-                "cache",
+                "clock",
+                "now",
                 "psr",
-                "psr-6"
+                "psr-20",
+                "time"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
-            "time": "2021-02-03T23:26:27+00:00"
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",
@@ -786,30 +1051,30 @@
         },
         {
             "name": "psr/log",
-            "version": "2.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "src"
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -830,1470 +1095,1687 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/2.0.0"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2021-07-14T16:41:46+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v5.4.24",
+            "name": "roave/security-advisories",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "69dafab8a5dffa4d6a4d6dab1ebadf48aca449c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/69dafab8a5dffa4d6a4d6dab1ebadf48aca449c7",
+                "reference": "69dafab8a5dffa4d6a4d6dab1ebadf48aca449c7",
                 "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
-                "psr/log": ">=3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/lock": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command-line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.24"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-26T05:13:16+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v5.4.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<4.4"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.22"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-17T11:31:58+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/event-dispatcher": "^1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to dispatching event",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v5.4.25",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
-                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-31T13:04:02+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v5.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Finds files and directories via an intuitive fluent interface",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.21"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-16T09:33:00+00:00"
-        },
-        {
-            "name": "symfony/options-resolver",
-            "version": "v5.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
-                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php73": "~1.0",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\OptionsResolver\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an improved replacement for the array_replace PHP function",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "config",
-                "configuration",
-                "options"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.21"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-14T08:03:56+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
+                "3f/pygmentize": "<1.2",
+                "admidio/admidio": "<4.2.10",
+                "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
+                "aheinze/cockpit": "<2.2",
+                "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
+                "akaunting/akaunting": "<2.1.13",
+                "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
+                "alextselegidis/easyappointments": "<1.5",
+                "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+                "amazing/media2click": ">=1,<1.3.3",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<1.0.1",
+                "amphp/http-client": ">=4,<4.4",
+                "anchorcms/anchor-cms": "<=0.12.7",
+                "andreapollastri/cipi": "<=3.1.15",
+                "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<1.0.2|>=2,<2.2.5",
+                "apereo/phpcas": "<1.6",
+                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6|>=2.6,<2.7.10|>=3,<3.0.12|>=3.1,<3.1.3",
+                "appwrite/server-ce": "<=1.2.1",
+                "arc/web": "<3",
+                "area17/twill": "<1.2.5|>=2,<2.5.3",
+                "artesaos/seotools": "<0.17.2",
+                "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
+                "athlon1600/php-proxy": "<=5.1",
+                "athlon1600/php-proxy-app": "<=3",
+                "automad/automad": "<1.8",
+                "awesome-support/awesome-support": "<=6.0.7",
+                "aws/aws-sdk-php": ">=3,<3.2.1",
+                "azuracast/azuracast": "<0.18.3",
+                "backdrop/backdrop": "<1.24.2",
+                "backpack/crud": "<3.4.9",
+                "badaso/core": "<2.7",
+                "bagisto/bagisto": "<0.1.5",
+                "barrelstrength/sprout-base-email": "<1.2.7",
+                "barrelstrength/sprout-forms": "<3.9",
+                "barryvdh/laravel-translation-manager": "<0.6.2",
+                "barzahlen/barzahlen-php": "<2.0.1",
+                "baserproject/basercms": "<4.7.5",
+                "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
+                "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
+                "billz/raspap-webgui": "<2.8.9",
+                "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
+                "bmarshall511/wordpress_zero_spam": "<5.2.13",
+                "bolt/bolt": "<3.7.2",
+                "bolt/core": "<=4.2",
+                "bottelet/flarepoint": "<2.2.1",
+                "brightlocal/phpwhois": "<=4.2.5",
+                "brotkrueml/codehighlight": "<2.7",
+                "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
+                "brotkrueml/typo3-matomo-integration": "<1.3.2",
+                "buddypress/buddypress": "<7.2.1",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "bytefury/crater": "<6.0.2",
+                "cachethq/cachet": "<2.5.1",
+                "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10|= 1.3.7|>=4.1,<4.1.4",
+                "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
+                "cardgate/magento2": "<2.0.33",
+                "cardgate/woocommerce": "<=3.1.15",
+                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<=2.1.6",
+                "catfan/medoo": "<1.7.5",
+                "centreon/centreon": "<22.10-beta.1",
+                "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+                "cockpit-hq/cockpit": "<2.6",
+                "codeception/codeception": "<3.1.3|>=4,<4.1.22",
+                "codeigniter/framework": "<=3.0.6",
+                "codeigniter4/framework": "<4.3.5",
+                "codeigniter4/shield": "<1-beta.4|= 1.0.0-beta",
+                "codiad/codiad": "<=2.8.4",
+                "composer/composer": "<1.10.26|>=2-alpha.1,<2.2.12|>=2.3,<2.3.5",
+                "concrete5/concrete5": "<9.2|>= 9.0.0RC1, < 9.1.3",
+                "concrete5/core": "<8.5.8|>=9,<9.1",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4",
+                "contao/core": ">=2,<3.5.39",
+                "contao/core-bundle": "<4.9.42|>=4.10,<4.13.28|>=5,<5.1.10|= 4.10.0",
+                "contao/listing-bundle": ">=4,<4.4.8",
+                "contao/managed-edition": "<=1.5",
+                "cosenary/instagram": "<=2.3",
+                "craftcms/cms": "<=4.4.9|>= 4.0.0-RC1, < 4.4.12|>= 4.0.0-RC1, <= 4.4.5|>= 4.0.0-RC1, <= 4.4.6|>= 4.0.0-RC1, < 4.4.6|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
+                "croogo/croogo": "<3.0.7",
+                "cuyz/valinor": "<0.12",
+                "czproject/git-php": "<4.0.3",
+                "darylldoyle/safe-svg": "<1.9.10",
+                "datadog/dd-trace": ">=0.30,<0.30.2",
+                "david-garcia/phpwhois": "<=4.3.1",
+                "dbrisinajumi/d2files": "<1",
+                "dcat/laravel-admin": "<=2.1.3-beta",
+                "derhansen/fe_change_pwd": "<2.0.5|>=3,<3.0.3",
+                "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
+                "desperado/xml-bundle": "<=0.1.7",
+                "directmailteam/direct-mail": "<5.2.4",
+                "doctrine/annotations": ">=1,<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2|>=3,<3.1.4",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<=0.7.1",
+                "doctrine/mongodb-odm": ">=1,<1.0.2",
+                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
+                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
+                "dolibarr/dolibarr": "<17.0.1|= 12.0.5|>= 3.3.beta1, < 13.0.2",
+                "dompdf/dompdf": "<2.0.2|= 2.0.2",
+                "drupal/core": ">=7,<7.96|>=8,<9.4.14|>=9.5,<9.5.8|>=10,<10.0.8",
+                "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
+                "dweeves/magmi": "<=0.7.24",
+                "ecodev/newsletter": "<=4",
+                "ectouch/ectouch": "<=2.7.2",
+                "elefant/cms": "<1.3.13",
+                "elgg/elgg": "<3.3.24|>=4,<4.0.5",
+                "encore/laravel-admin": "<=1.8.19",
+                "endroid/qr-code-bundle": "<3.4.2",
+                "enshrined/svg-sanitize": "<0.15",
+                "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
+                "exceedone/exment": "<4.4.3|>=5,<5.0.3",
+                "exceedone/laravel-admin": "= 3.0.0|<2.2.3",
+                "ezsystems/demobundle": ">=5.4,<5.4.6.1",
+                "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
+                "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
+                "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
+                "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.26",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+                "ezsystems/ezplatform-graphql": ">=1-rc.1,<1.0.13|>=2-beta.1,<2.3.12",
+                "ezsystems/ezplatform-kernel": "<1.2.5.1|>=1.3,<1.3.26",
+                "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
+                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.7.1",
+                "ezsystems/ezplatform-user": ">=1,<1.0.1",
+                "ezsystems/ezpublish-kernel": "<6.13.8.2|>=7,<7.5.30",
+                "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.3.5.1",
+                "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
+                "ezsystems/repository-forms": ">=2.3,<2.3.2.1|>=2.5,<2.5.15",
+                "ezyang/htmlpurifier": "<4.1.1",
+                "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
+                "facturascripts/facturascripts": "<=2022.8",
+                "feehi/cms": "<=2.1.1",
+                "feehi/feehicms": "<=2.1.1",
+                "fenom/fenom": "<=2.12.1",
+                "filegator/filegator": "<7.8",
+                "firebase/php-jwt": "<6",
+                "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
+                "fixpunkt/fp-newsletter": "<1.1.1|>=2,<2.1.2|>=2.2,<3.2.6",
+                "flarum/core": "<1.7",
+                "flarum/framework": "<=0.1-beta.7.1",
+                "flarum/mentions": "<1.6.3",
+                "flarum/sticky": ">=0.1-beta.14,<=0.1-beta.15",
+                "flarum/tags": "<=0.1-beta.13",
+                "fluidtypo3/vhs": "<5.1.1",
+                "fof/byobu": ">=0.3-beta.2,<1.1.7",
+                "fof/upload": "<1.2.3",
+                "fooman/tcpdf": "<6.2.22",
+                "forkcms/forkcms": "<5.11.1",
+                "fossar/tcpdf-parser": "<6.2.22",
+                "francoisjacquet/rosariosis": "<11",
+                "frappant/frp-form-answers": "<3.1.2|>=4,<4.0.2",
+                "friendsofsymfony/oauth2-php": "<1.3",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "froala/wysiwyg-editor": "<3.2.7",
+                "froxlor/froxlor": "<2.1",
+                "fuel/core": "<1.8.1",
+                "funadmin/funadmin": "<=3.2|>=3.3.2,<=3.3.3",
+                "gaoming13/wechat-php-sdk": "<=1.10.2",
+                "genix/cms": "<=1.1.11",
+                "getgrav/grav": "<=1.7.42.1",
+                "getkirby/cms": "= 3.8.0|<3.5.8.2|>=3.6,<3.6.6.2|>=3.7,<3.7.5.1",
+                "getkirby/kirby": "<=2.5.12",
+                "getkirby/panel": "<2.5.14",
+                "getkirby/starterkit": "<=3.7.0.2",
+                "gilacms/gila": "<=1.11.4",
+                "globalpayments/php-sdk": "<2",
+                "gogentooss/samlbase": "<1.2.7",
+                "google/protobuf": "<3.15",
+                "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
+                "gree/jose": "<2.2.1",
+                "gregwar/rst": "<1.0.3",
+                "grumpydictator/firefly-iii": "<6",
+                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
+                "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
+                "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
+                "harvesthq/chosen": "<1.8.7",
+                "helloxz/imgurl": "= 2.31|<=2.31",
+                "hhxsv5/laravel-s": "<3.7.36",
+                "hillelcoren/invoice-ninja": "<5.3.35",
+                "himiklab/yii2-jqgrid-widget": "<1.0.8",
+                "hjue/justwriting": "<=1",
+                "hov/jobfair": "<1.0.13|>=2,<2.0.2",
+                "httpsoft/http-message": "<1.0.12",
+                "hyn/multi-tenant": ">=5.6,<5.7.2",
+                "ibexa/admin-ui": ">=4.2,<4.2.3",
+                "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3",
+                "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
+                "ibexa/post-install": "<=1.0.4",
+                "ibexa/user": ">=4,<4.4.3",
+                "icecoder/icecoder": "<=8.1",
+                "idno/known": "<=1.3.1",
+                "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
+                "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
+                "impresscms/impresscms": "<=1.4.5",
+                "in2code/femanager": "<5.5.3|>=6,<6.3.4|>=7,<7.1",
+                "in2code/ipandlanguageredirect": "<5.1.2",
+                "in2code/lux": "<17.6.1|>=18,<24.0.2",
+                "innologi/typo3-appointments": "<2.0.6",
+                "intelliants/subrion": "<=4.2.1",
+                "islandora/islandora": ">=2,<2.4.1",
+                "ivankristianto/phpwhois": "<=4.3",
+                "jackalope/jackalope-doctrine-dbal": "<1.7.4",
+                "james-heinrich/getid3": "<1.9.21",
+                "jasig/phpcas": "<1.3.3",
+                "joomla/archive": "<1.1.12|>=2,<2.0.1",
+                "joomla/filesystem": "<1.6.2|>=2,<2.0.1",
+                "joomla/filter": "<1.4.4|>=2,<2.0.1",
+                "joomla/framework": ">=2.5.4,<=3.8.12",
+                "joomla/input": ">=2,<2.0.2",
+                "joomla/joomla-cms": ">=3,<3.9.12",
+                "joomla/session": "<1.3.1",
+                "joyqi/hyper-down": "<=2.4.27",
+                "jsdecena/laracom": "<2.0.9",
+                "jsmitty12/phpwhois": "<5.1",
+                "kazist/phpwhois": "<=4.2.6",
+                "kelvinmo/simplexrd": "<3.1.1",
+                "kevinpapst/kimai2": "<1.16.7",
+                "khodakhah/nodcms": "<=3",
+                "kimai/kimai": "<1.1",
+                "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
+                "klaviyo/magento2-extension": ">=1,<3",
+                "knplabs/knp-snappy": "<1.4.2",
+                "krayin/laravel-crm": "<1.2.2",
+                "kreait/firebase-php": ">=3.2,<3.8.1",
+                "la-haute-societe/tcpdf": "<6.2.22",
+                "laminas/laminas-diactoros": "<2.18.1|>=2.24,<2.24.2|>=2.25,<2.25.2|= 2.23.0|= 2.22.0|= 2.21.0|= 2.20.0|= 2.19.0",
+                "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
+                "laminas/laminas-http": "<2.14.2",
+                "laravel/fortify": "<1.11.1",
+                "laravel/framework": "<6.20.44|>=7,<7.30.6|>=8,<8.75",
+                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
+                "latte/latte": "<2.10.8",
+                "lavalite/cms": "= 9.0.0|<=9",
+                "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
+                "league/commonmark": "<0.18.3",
+                "league/flysystem": "<1.1.4|>=2,<2.1.1",
+                "league/oauth2-server": ">=8.3.2,<8.5.3",
+                "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
+                "librenms/librenms": "<22.10",
+                "liftkit/database": "<2.13.2",
+                "limesurvey/limesurvey": "<3.27.19",
+                "livehelperchat/livehelperchat": "<=3.91",
+                "livewire/livewire": ">2.2.4,<2.2.6",
+                "lms/routes": "<2.1.1",
+                "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
+                "luyadev/yii-helpers": "<1.2.1",
+                "magento/community-edition": "= 2.4.0|<=2.4",
+                "magento/magento1ce": "<1.9.4.3",
+                "magento/magento1ee": ">=1,<1.14.4.3",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
+                "maikuolan/phpmussel": ">=1,<1.6",
+                "mantisbt/mantisbt": "<=2.25.5",
+                "marcwillmann/turn": "<0.3.3",
+                "matyhtf/framework": "<3.0.6",
+                "mautic/core": "<4.3|= 2.13.1",
+                "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
+                "mediawiki/matomo": "<2.4.3",
+                "melisplatform/melis-asset-manager": "<5.0.1",
+                "melisplatform/melis-cms": "<5.0.1",
+                "melisplatform/melis-front": "<5.0.1",
+                "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
+                "mgallegos/laravel-jqgrid": "<=1.3",
+                "microweber/microweber": "<=1.3.4|= 1.1.18",
+                "miniorange/miniorange-saml": "<1.4.3",
+                "mittwald/typo3_forum": "<1.2.1",
+                "mobiledetect/mobiledetectlib": "<2.8.32",
+                "modx/revolution": "<2.8|<= 2.8.3-pl",
+                "mojo42/jirafeau": "<4.4",
+                "monolog/monolog": ">=1.8,<1.12",
+                "moodle/moodle": "<4.2-rc.2|= 3.4.3|= 3.5|= 3.7|= 3.9|= 3.8|= 4.2.0|= 3.11",
+                "movim/moxl": ">=0.8,<=0.10",
+                "mpdf/mpdf": "<=7.1.7",
+                "mustache/mustache": ">=2,<2.14.1",
+                "namshi/jose": "<2.2",
+                "neoan3-apps/template": "<1.1.1",
+                "neorazorx/facturascripts": "<2022.4",
+                "neos/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "neos/form": ">=1.2,<4.3.3|>=5,<5.0.9|>=5.1,<5.1.3",
+                "neos/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.9.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<5.3.10|>=7,<7.0.9|>=7.1,<7.1.7|>=7.2,<7.2.6|>=7.3,<7.3.4|>=8,<8.0.2",
+                "neos/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "netgen/tagsbundle": ">=3.4,<3.4.11|>=4,<4.0.15",
+                "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
+                "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+                "nilsteampassnet/teampass": "<3.0.10",
+                "notrinos/notrinos-erp": "<=0.7",
+                "noumo/easyii": "<=0.9",
+                "nukeviet/nukeviet": "<4.5.2",
+                "nyholm/psr7": "<1.6.1",
+                "nystudio107/craft-seomatic": "<3.4.12",
+                "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+                "october/backend": "<1.1.2",
+                "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
+                "october/october": "<1.0.466|>=2.1,<2.1.12",
+                "october/rain": "<1.0.472|>=1.1,<1.1.2",
+                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.34|>=3,<3.0.66",
+                "onelogin/php-saml": "<2.10.4",
+                "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
+                "open-web-analytics/open-web-analytics": "<1.7.4",
+                "opencart/opencart": "<=3.0.3.7",
+                "openid/php-openid": "<2.3",
+                "openmage/magento-lts": "<19.4.22|>=20,<20.0.19",
+                "opensource-workshop/connect-cms": "<1.7.2|>=2,<2.3.2",
+                "orchid/platform": ">=9,<9.4.4|>=14-alpha.4,<14.5",
+                "oro/commerce": ">=4.1,<5.0.6",
+                "oro/crm": ">=1.7,<1.7.4|>=3.1,<4.1.17|>=4.2,<4.2.7",
+                "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<4.2.8",
+                "packbackbooks/lti-1-3-php-library": "<5",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": ">=0,<3",
+                "pagekit/pagekit": "<=1.0.18",
+                "paragonie/random_compat": "<2",
+                "passbolt/passbolt_api": "<2.11",
+                "paypal/merchant-sdk-php": "<3.12",
+                "pear/archive_tar": "<1.4.14",
+                "pear/crypt_gpg": "<1.6.7",
+                "pear/pear": "<=1.10.1",
+                "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
+                "personnummer/personnummer": "<3.0.2",
+                "phanan/koel": "<5.1.4",
+                "php-mod/curl": "<2.3.2",
+                "phpbb/phpbb": "<3.2.10|>=3.3,<3.3.1",
+                "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
+                "phpmailer/phpmailer": "<6.5",
+                "phpmussel/phpmussel": ">=1,<1.6",
+                "phpmyadmin/phpmyadmin": "<5.2.1",
+                "phpmyfaq/phpmyfaq": "<=3.1.7",
+                "phpoffice/phpexcel": "<1.8",
+                "phpoffice/phpspreadsheet": "<1.16",
+                "phpseclib/phpseclib": "<2.0.31|>=3,<3.0.19",
+                "phpservermon/phpservermon": "<3.6",
+                "phpsysinfo/phpsysinfo": "<3.2.5",
+                "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5,<5.6.3",
+                "phpwhois/phpwhois": "<=4.2.5",
+                "phpxmlrpc/extras": "<0.6.1",
+                "phpxmlrpc/phpxmlrpc": "<4.9.2",
+                "pi/pi": "<=2.5",
+                "pimcore/admin-ui-classic-bundle": "<1.0.3",
+                "pimcore/customer-management-framework-bundle": "<3.4.1",
+                "pimcore/data-hub": "<1.2.4",
+                "pimcore/perspective-editor": "<1.5.1",
+                "pimcore/pimcore": "<10.6.4",
+                "pixelfed/pixelfed": "<=0.11.4",
+                "pocketmine/bedrock-protocol": "<8.0.2",
+                "pocketmine/pocketmine-mp": "<4.22.3|>=5,<5.2.1|< 4.18.0-ALPHA2|>= 4.0.0-BETA5, < 4.4.2",
+                "pressbooks/pressbooks": "<5.18",
+                "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/blockwishlist": ">=2,<2.1.1",
+                "prestashop/contactform": ">=1.0.1,<4.3",
+                "prestashop/gamification": "<2.3.2",
+                "prestashop/prestashop": "<8.0.4",
+                "prestashop/productcomments": "<5.0.2",
+                "prestashop/ps_emailsubscription": "<2.6.1",
+                "prestashop/ps_facetedsearch": "<3.4.1",
+                "prestashop/ps_linklist": "<3.1",
+                "privatebin/privatebin": "<1.4",
+                "processwire/processwire": "<=3.0.200",
+                "propel/propel": ">=2-alpha.1,<=2-alpha.7",
+                "propel/propel1": ">=1,<=1.7.1",
+                "pterodactyl/panel": "<1.7",
+                "ptrofimov/beanstalk_console": "<1.7.14",
+                "pusher/pusher-php-server": "<2.2.1",
+                "pwweb/laravel-core": "<=0.3.6-beta",
+                "pyrocms/pyrocms": "<=3.9.1",
+                "rainlab/debugbar-plugin": "<3.1",
+                "rankmath/seo-by-rank-math": "<=1.0.95",
+                "rap2hpoutre/laravel-log-viewer": "<0.13",
+                "react/http": ">=0.7,<1.9",
+                "really-simple-plugins/complianz-gdpr": "<6.4.2",
+                "remdex/livehelperchat": "<3.99",
+                "rmccue/requests": ">=1.6,<1.8",
+                "robrichards/xmlseclibs": "<3.0.4",
+                "roots/soil": "<4.1",
+                "rudloff/alltube": "<3.0.3",
+                "s-cart/core": "<6.9",
+                "s-cart/s-cart": "<6.9",
+                "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
+                "sabre/dav": "<1.7.11|>=1.8,<1.8.9",
+                "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
+                "sensiolabs/connect": "<4.2.3",
+                "serluck/phpwhois": "<=4.2.6",
+                "sfroemken/url_redirect": "<=1.2.1",
+                "sheng/yiicms": "<=1.2",
+                "shopware/core": "<=6.4.20",
+                "shopware/platform": "<=6.4.20",
+                "shopware/production": "<=6.3.5.2",
+                "shopware/shopware": "<=5.7.17",
+                "shopware/storefront": "<=6.4.8.1",
+                "shopxo/shopxo": "<2.2.6",
+                "showdoc/showdoc": "<2.10.4",
+                "silverstripe-australia/advancedreports": ">=1,<=2",
+                "silverstripe/admin": "<1.12.7",
+                "silverstripe/assets": ">=1,<1.11.1",
+                "silverstripe/cms": "<4.11.3",
+                "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
+                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/framework": "<4.12.5",
+                "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2|>=4.1.1,<4.1.2|>=4.2.2,<4.2.3|= 4.0.0-alpha1",
+                "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
+                "silverstripe/recipe-cms": ">=4.5,<4.5.3",
+                "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+                "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
+                "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
+                "silverstripe/subsites": ">=2,<2.6.1",
+                "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+                "silverstripe/userforms": "<3",
+                "silverstripe/versioned-admin": ">=1,<1.11.1",
+                "simple-updates/phpwhois": "<=1",
+                "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
+                "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "simplesamlphp/simplesamlphp-module-openid": "<1",
+                "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
+                "simplito/elliptic-php": "<1.0.6",
+                "sitegeist/fluid-components": "<3.5",
+                "sjbr/sr-freecap": "<=2.5.2",
+                "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
+                "slim/slim": "<2.6",
+                "smarty/smarty": "<3.1.48|>=4,<4.3.1",
+                "snipe/snipe-it": "<=6.0.14|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "socialiteproviders/steam": "<1.1",
+                "spatie/browsershot": "<3.57.4",
+                "spipu/html2pdf": "<5.2.4",
+                "spoon/library": "<1.4.1",
+                "spoonity/tcpdf": "<6.2.22",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "ssddanbrown/bookstack": "<22.2.3",
+                "statamic/cms": "<4.10",
+                "stormpath/sdk": ">=0,<9.9.99",
+                "studio-42/elfinder": "<2.1.62",
+                "subhh/libconnect": "<7.0.8|>=8,<8.1",
+                "subrion/cms": "<=4.2.1",
+                "sukohi/surpass": "<1",
+                "sulu/sulu": "= 2.4.0-RC1|<1.6.44|>=2,<2.2.18|>=2.3,<2.3.8",
+                "sumocoders/framework-user-bundle": "<1.4",
+                "swag/paypal": "<5.4.4",
+                "swiftmailer/swiftmailer": ">=4,<5.4.5",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/grid-bundle": "<1.10.1",
+                "sylius/paypal-plugin": ">=1,<1.2.4|>=1.3,<1.3.1",
+                "sylius/resource-bundle": "<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
+                "sylius/sylius": "<1.9.10|>=1.10,<1.10.11|>=1.11,<1.11.2",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
+                "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
+                "symbiote/silverstripe-seed": "<6.0.3",
+                "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+                "symfont/process": ">=0",
+                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<=5.3.14|>=5.4.3,<=5.4.3|>=6.0.3,<=6.0.3|= 6.0.3|= 5.4.3|= 5.3.14",
+                "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
+                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/routing": ">=2,<2.0.19",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
+                "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
+                "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.3.2",
+                "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
+                "symfony/symfony": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
+                "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
+                "t3/dce": ">=2.2,<2.6.2",
+                "t3g/svg-sanitizer": "<1.0.3",
+                "tastyigniter/tastyigniter": "<3.3",
+                "tcg/voyager": "<=1.4",
+                "tecnickcom/tcpdf": "<6.2.22",
+                "terminal42/contao-tablelookupwizard": "<3.3.5",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1-beta.1,<2.1.3",
+                "theonedemon/phpwhois": "<=4.2.5",
+                "thinkcmf/thinkcmf": "<=5.1.7",
+                "thorsten/phpmyfaq": "<3.2-beta.2",
+                "tinymce/tinymce": "<5.10.7|>=6,<6.3.1",
+                "tinymighty/wiki-seo": "<1.2.2",
+                "titon/framework": ">=0,<9.9.99",
+                "tobiasbg/tablepress": "<= 2.0-RC1",
+                "topthink/framework": "<6.0.14",
+                "topthink/think": "<=6.1.1",
+                "topthink/thinkphp": "<=3.2.3",
+                "tpwd/ke_search": "<4.0.3|>=4.1,<4.6.6|>=5,<5.0.2",
+                "tribalsystems/zenario": "<=9.3.57595",
+                "truckersmp/phpwhois": "<=4.3.1",
+                "ttskch/pagination-service-provider": "<1",
+                "twig/twig": "<1.44.7|>=2,<2.15.3|>=3,<3.4.3",
+                "typo3/cms": "<2.0.5|>=3,<3.0.3|>=6.2,<=6.2.38|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
+                "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
+                "typo3/cms-core": "<8.7.51|>=9,<9.5.42|>=10,<10.4.39|>=11,<11.5.30|>=12,<12.4.4",
+                "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "typo3/html-sanitizer": ">=1,<1.5.1|>=2,<2.1.2",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
+                "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+                "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
+                "ua-parser/uap-php": "<3.8",
+                "unisharp/laravel-filemanager": "<=2.5.1",
+                "userfrosting/userfrosting": ">=0.3.1,<4.6.3",
+                "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+                "uvdesk/community-skeleton": "<=1.1.1",
+                "vanilla/safecurl": "<0.9.2",
+                "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
+                "vova07/yii2-fileapi-widget": "<0.1.9",
+                "vrana/adminer": "<4.8.1",
+                "wallabag/tcpdf": "<6.2.22",
+                "wallabag/wallabag": "<=2.5.4",
+                "wanglelecc/laracms": "<=1.0.3",
+                "web-auth/webauthn-framework": ">=3.3,<3.3.4",
+                "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
+                "webcoast/deferred-image-processing": "<1.0.2",
+                "webklex/laravel-imap": "<5.3",
+                "webklex/php-imap": "<5.3",
+                "webpa/webpa": "<3.1.2",
+                "wikibase/wikibase": "<=1.39.3",
+                "wikimedia/parsoid": "<0.12.2",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "wintercms/winter": "<1.2.3",
+                "woocommerce/woocommerce": "<6.6",
+                "wp-cli/wp-cli": "<2.5",
+                "wp-graphql/wp-graphql": "<=1.14.5",
+                "wpanel/wpanel4-cms": "<=4.3.1",
+                "wpcloud/wp-stateless": "<3.2",
+                "wwbn/avideo": "<=12.4",
+                "xataface/xataface": "<3",
+                "xpressengine/xpressengine": "<3.0.15",
+                "yeswiki/yeswiki": "<4.1",
+                "yetiforce/yetiforce-crm": "<=6.4",
+                "yidashi/yii2cmf": "<=2",
+                "yii2mod/yii2-cms": "<1.9.2",
+                "yiisoft/yii": "<1.1.27",
+                "yiisoft/yii2": "<2.0.38",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.43",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
+                "yiisoft/yii2-gii": "<=2.2.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.8",
+                "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
+                "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
+                "yourls/yourls": "<=1.8.2",
+                "zencart/zencart": "<1.5.8",
+                "zendesk/zendesk_api_client_php": "<2.2.11",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+                "zendframework/zend-diactoros": "<1.8.4",
+                "zendframework/zend-feed": "<2.10.3",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": "<2.8.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": "<=3",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": ">=2,<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zenstruck/collection": "<0.2.1",
+                "zetacomponents/mail": "<1.8.2",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2",
+                "zoujingli/thinkadmin": "<6.0.22"
             },
             "type": "metapackage",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.20-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
                 },
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Ilya Tribusean",
+                    "email": "slash3b@gmail.com",
+                    "role": "maintainer"
                 }
             ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
             "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
+                "dev"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php70/tree/v1.20.0"
+                "issues": "https://github.com/Roave/SecurityAdvisories/issues",
+                "source": "https://github.com/Roave/SecurityAdvisories/tree/latest"
             },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/Ocramius",
                     "type": "github"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2023-07-25T19:04:12+00:00"
         },
         {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.27.0",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v5.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e3c46cc5689c8782944274bb30702106ecbe3b64",
-                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.24"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-17T11:26:05+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^2.0"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/stopwatch",
-            "version": "v5.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f83692cd869a6f2391691d40a01e8acb89e76fee",
-                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/service-contracts": "^1|^2|^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Stopwatch\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides a way to profile code",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.21"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-14T08:03:56+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v6.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
-                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "conflict": {
-                "symfony/translation-contracts": "<2.5"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/intl": "^6.2",
-                "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.3.0"
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
             },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2023-03-21T21:06:29+00:00"
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T12:41:17+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-07T05:35:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T06:03:37+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-14T08:28:10+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:07:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "roave/security-advisories": 20,
+        "nextcloud/ocp": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-mbstring": "*"
+    },
+    "platform-overrides": {
+        "php": "8.0"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/css/nmcdefault.css
+++ b/css/nmcdefault.css
@@ -45,10 +45,10 @@
   --default-font-size: 15px;
   --animation-quick: 100ms;
   --animation-slow: 300ms;
-  --border-radius: 3px;
-  --border-radius-large: 10px;
-  --border-radius-rounded: 28px;
-  --border-radius-pill: 100px;
+  --border-radius: var(--telekom-radius-standard);
+  --border-radius-large: var(--telekom-radius-large);
+  --border-radius-rounded: 0px;
+  --border-radius-pill: var(--telekom-radius-pill);
   --default-clickable-area: 44px;
   --default-line-height: 24px;
   --default-grid-baseline: 4px;
@@ -80,6 +80,6 @@
   --color-primary-element-light-text: #002a41;
   --color-primary-element-text-dark: #ededed;
   --gradient-primary-background: linear-gradient(40deg, var(--color-primary) 0%, var(--color-primary-hover) 100%);
-  --image-background-default: url('/apps/theming/img/background/kamil-porembinski-clouds.jpg');
-  --color-background-plain: var(--telekom-color-primary-standard);
+  /* --image-background-default: url('/apps/theming/img/background/kamil-porembinski-clouds.jpg'); */
+  --color-background-plain: var(--telekom-color-background-canvas);
 }

--- a/css/nmcdefault.scss
+++ b/css/nmcdefault.scss
@@ -1,0 +1,93 @@
+/**
+ * The MagentaCLOUD default settings that are always used as baseline fallback
+ *
+ * @copyright Copyright (c) 2023 T-Systems International
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Note: Take care of Telekom branding restrictions!
+ */
+@use "sass:color";
+
+:root {
+  --color-main-background: var(--telekom-color-background-canvas);
+  --color-main-background-translucent: rgba(var(--telekom-color-background-canvas), .97); /* only works in scss */
+  --color-main-background-blur: rgba(var(--telekom-color-background-canvas), .8);
+  --filter-background-blur: blur(25px);
+  --gradient-main-background: var(--color-main-background) 0%, var(--color-main-background-translucent) 85%, transparent 100%;
+  --color-background-hover: #f5f5f5;
+  --color-background-dark: #ededed;
+  --color-background-darker: #dbdbdb;
+  --color-placeholder-light: #e6e6e6;
+  --color-placeholder-dark: #cccccc;
+  --color-main-text: var(--telekom-color-text-and-icon-standard);
+  --color-text-maxcontrast: var(--telekom-color-text-and-icon-additional);
+  --color-text-maxcontrast-default: var(--telekom-color-text-and-icon-additional);
+  --color-text-maxcontrast-background-blur: var(--telekom-color-text-and-icon-disabled);
+  --color-text-light: var(--telekom-color-ui-extra-strong);
+  --color-text-lighter:var(--telekom-color-ui-strong);
+  --color-scrollbar: rgba(34,34,34, .15);
+  --color-error: #e9322d;
+  --color-error-rgb: 233,50,45;
+  --color-error-hover: #ed5a56;
+  --color-error-text: #e7201b;
+  --color-warning: #c28900;
+  --color-warning-rgb: 194,137,0;
+  --color-warning-hover: #cea032;
+  --color-warning-text: #996c00;
+  --color-success: #3fa857;
+  --color-success-rgb: 63,168,87;
+  --color-success-hover: #65b978;
+  --color-success-text: #318344;
+  --color-info: #006aa3;
+  --color-info-rgb: 0,106,163;
+  --color-info-hover: #3287b5;
+  --color-info-text: #006aa3;
+  --color-loading-light: #cccccc;
+  --color-loading-dark: #444444;
+  --color-box-shadow-rgb: 77,77,77;
+  --color-box-shadow: rgba(var(--color-box-shadow-rgb), 0.5);
+  --color-border: #ededed;
+  --color-border-dark: #dbdbdb;
+  --color-border-maxcontrast: #949494;
+  --font-face: TeleNeoWeb, sans-serif, Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  --default-font-size: 15px;
+  --animation-quick: 100ms;
+  --animation-slow: 300ms;
+  --border-radius: var(--telekom-radius-standard);
+  --border-radius-large: var(--telekom-radius-large);
+  --border-radius-rounded: 0px;
+  --border-radius-pill: var(--telekom-radius-pill);
+  --default-clickable-area: 44px;
+  --default-line-height: 24px;
+  --default-grid-baseline: 4px;
+  --header-height: 50px;
+  --navigation-width: 300px;
+  --sidebar-min-width: 300px;
+  --sidebar-max-width: 500px;
+  --list-min-width: 200px;
+  --list-max-width: 300px;
+  --header-menu-item-height: 44px;
+  --header-menu-profile-item-height: 66px;
+  --breakpoint-mobile: 1024px;
+  --background-invert-if-dark: no;
+  --background-invert-if-bright: invert(100%);
+  --background-image-invert-if-bright: no;
+  --primary-invert-if-bright: no;
+  --color-primary: var(--telekom-color-primary-standard);
+  --color-primary-default: #0082c9;
+  --color-primary-text: #ffffff;
+  --color-primary-hover: #3287b5;
+  --color-primary-light: #e5f0f5;
+  --color-primary-light-text: #002a41;
+  --color-primary-light-hover: #dbe5ea;
+  --color-primary-element: var(--telekom-color-primary-standard);
+  --color-primary-element-hover: var(--telekom-color-primary-hovered);
+  --color-primary-element-text: #ffffff;
+  --color-primary-element-light: #e5f0f5;
+  --color-primary-element-light-hover: #dbe5ea;
+  --color-primary-element-light-text: #002a41;
+  --color-primary-element-text-dark: #ededed;
+  --gradient-primary-background: linear-gradient(40deg, var(--color-primary) 0%, var(--color-primary-hover) 100%);
+  /* --image-background-default: url('/apps/theming/img/background/kamil-porembinski-clouds.jpg'); */
+  --color-background-plain: var(--telekom-color-background-canvas);
+}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,14 +8,23 @@
  */
 namespace OCA\NMCTheme\AppInfo;
 
+use OCP\IUserSession;
+use OCP\IConfig;
 use OCA\NMCTheme\Listener\BeforeTemplateRenderedListener;
+use OCA\NMCTheme\Service\NMCThemesService;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
-
+use Psr\Container\ContainerInterface;
 use OCA\Theming\Service\ThemesService;
+use OCA\Theming\Themes\DarkHighContrastTheme;
+use OCA\Theming\Themes\DarkTheme;
+use OCA\Theming\Themes\DefaultTheme;
+use OCA\Theming\Themes\DyslexiaFont;
+use OCA\Theming\Themes\HighContrastTheme;
+use OCA\Theming\Themes\LightTheme;
 use OCA\NMCTheme\Themes\Magenta;
 use OCA\NMCTheme\Themes\MagentaDark;
 use OCA\NMCTheme\Themes\TeleNeoWebFont;
@@ -28,23 +37,40 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
-		// the listener is helpful to enforce theme constraints and inject additional parts
-		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+		// explicitly register own NMCThemesManager to override the Nextcloud standard
+        $this->getContainer()->registerService(ThemesService::class, function(ContainerInterface $c) {
+            return new NMCThemesService(
+                $c->get(IUserSession::class),
+                $c->get(IConfig::class),
+                $c->get(Magenta::class),        
+                [$c->get(MagentaDark::class)],
+                [$c->get(TeleNeoWebFont::class)],
+                $c->get(DefaultTheme::class),
+                $c->get(LightTheme::class),
+                $c->get(DarkTheme::class),
+                $c->get(HighContrastTheme::class),
+                $c->get(DarkHighContrastTheme::class),
+                $c->get(DyslexiaFont::class)
+            );
+        });
+        
+        // the listener is helpful to enforce theme constraints and inject additional parts
+		// $context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {
-		/** @var ThemesService $themesService */
-		$themesService = $this->getContainer()->get(ThemesService::class);
+		// /** @var ThemesService $themesService */
+		// $themesService = $this->getContainer()->get(ThemesService::class);
 
-		/** @var Magenta $magentaDefault */
-		$magentaDefault = $this->getContainer()->get(Magenta::class);
+		// /** @var Magenta $magentaDefault */
+		// $magentaDefault = $this->getContainer()->get(Magenta::class);
 
-		/** @var MagentaDark $magentaDark */
-		$magentaDark = $this->getContainer()->get(MagentaDark::class);
+		// /** @var MagentaDark $magentaDark */
+		// $magentaDark = $this->getContainer()->get(MagentaDark::class);
 
-		/** @var TeleNeoWebFont $teleNeoWebFont */
-		$teleNeoWebFont = $this->getContainer()->get(TeleNeoWebFont::class);
+		// /** @var TeleNeoWebFont $teleNeoWebFont */
+		// $teleNeoWebFont = $this->getContainer()->get(TeleNeoWebFont::class);
 
-		$themesService->registerThemes([$teleNeoWebFont, $magentaDefault, $magentaDark], true);
+		// $themesService->registerThemes([$teleNeoWebFont, $magentaDefault, $magentaDark], true);
 	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -44,7 +44,7 @@ class Application extends App implements IBootstrap {
 			$container = \OC::$server->getRegisteredAppContainer($appName);
 		} catch (QueryException $e) {
 			$container = new DIContainer($appName);
-            \OC::$server->getRegisteredAppContainer($appName);
+            \OC::$server->registerAppContainer($appName, $container);
         }
 
         return $container;

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,18 +8,12 @@
  */
 namespace OCA\NMCTheme\AppInfo;
 
-use OCP\IUserSession;
-use OCP\IConfig;
 use OC\AppFramework\DependencyInjection\DIContainer;
-use OC\AppFramework\Utility\SimpleContainer;
-use OCP\AppFramework\QueryException;
 use OCA\NMCTheme\Listener\BeforeTemplateRenderedListener;
 use OCA\NMCTheme\Service\NMCThemesService;
-use OCP\AppFramework\App;
-use OCP\AppFramework\Bootstrap\IBootContext;
-use OCP\AppFramework\Bootstrap\IBootstrap;
-use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCA\NMCTheme\Themes\Magenta;
+use OCA\NMCTheme\Themes\MagentaDark;
+use OCA\NMCTheme\Themes\TeleNeoWebFont;
 use OCA\Theming\Service\ThemesService;
 use OCA\Theming\Themes\DarkHighContrastTheme;
 use OCA\Theming\Themes\DarkTheme;
@@ -27,9 +21,14 @@ use OCA\Theming\Themes\DefaultTheme;
 use OCA\Theming\Themes\DyslexiaFont;
 use OCA\Theming\Themes\HighContrastTheme;
 use OCA\Theming\Themes\LightTheme;
-use OCA\NMCTheme\Themes\Magenta;
-use OCA\NMCTheme\Themes\MagentaDark;
-use OCA\NMCTheme\Themes\TeleNeoWebFont;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\AppFramework\QueryException;
+use OCP\IConfig;
+use OCP\IUserSession;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'nmctheme';
@@ -38,54 +37,53 @@ class Application extends App implements IBootstrap {
 		parent::__construct(self::APP_ID);
 	}
 
-    public function getCapturedThemeingContainer() {
-        $appName = "theming";
+	/**
+	 * Services are aquired by DI with priority for registrations for the own app.
+	 * As ThemesService is registered before or after nmctheme, and we want to
+	 * register NMCTheme version instead we either have to:
+	 * - register a theming app container early if nmctheme is registered before
+	 *   theming
+	 * - use the already registered container if theming is registered before
+	 *   nmctheme
+	 *
+	 * The "foreign" theming container can the be used for enforcing the registration
+	 * of the NMCThemesService factory method.
+	 */
+	public function getCapturedThemeingContainer() {
+		$appName = "theming";
 		try {
 			$container = \OC::$server->getRegisteredAppContainer($appName);
 		} catch (QueryException $e) {
 			$container = new DIContainer($appName);
-            \OC::$server->registerAppContainer($appName, $container);
-        }
+			\OC::$server->registerAppContainer($appName, $container);
+		}
 
-        return $container;
-    }
+		return $container;
+	}
 
 	public function register(IRegistrationContext $context): void {
-        // getRegisteredAppContainer("theming")
+		// getRegisteredAppContainer("theming")
 		// explicitly register own NMCThemesManager to override the Nextcloud standard
-        $this->getCapturedThemeingContainer()->registerService(ThemesService::class, function($c) {
-            return new NMCThemesService(
-                $c->get(IUserSession::class),
-                $c->get(IConfig::class),
-                $c->get(Magenta::class),        
-                [$c->get(MagentaDark::class)],
-                [$c->get(TeleNeoWebFont::class)],
-                $c->get(DefaultTheme::class),   // the rest is overhead due to undefined interface (yet)
-                $c->get(LightTheme::class),
-                $c->get(DarkTheme::class),
-                $c->get(HighContrastTheme::class),
-                $c->get(DarkHighContrastTheme::class),
-                $c->get(DyslexiaFont::class)
-            );
-        });
-        
-        // the listener is helpful to enforce theme constraints and inject additional parts
+		$this->getCapturedThemeingContainer()->registerService(ThemesService::class, function ($c) {
+			return new NMCThemesService(
+				$c->get(IUserSession::class),
+				$c->get(IConfig::class),
+				$c->get(Magenta::class),
+				[$c->get(MagentaDark::class)],
+				[$c->get(TeleNeoWebFont::class)],
+				$c->get(DefaultTheme::class),   // the rest is overhead due to undefined interface (yet)
+				$c->get(LightTheme::class),
+				$c->get(DarkTheme::class),
+				$c->get(HighContrastTheme::class),
+				$c->get(DarkHighContrastTheme::class),
+				$c->get(DyslexiaFont::class)
+			);
+		});
+		
+		// the listener is helpful to enforce theme constraints and inject additional parts
 		// $context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {
-		// /** @var ThemesService $themesService */
-		// $themesService = $this->getContainer()->get(ThemesService::class);
-
-		// /** @var Magenta $magentaDefault */
-		// $magentaDefault = $this->getContainer()->get(Magenta::class);
-
-		// /** @var MagentaDark $magentaDark */
-		// $magentaDark = $this->getContainer()->get(MagentaDark::class);
-
-		// /** @var TeleNeoWebFont $teleNeoWebFont */
-		// $teleNeoWebFont = $this->getContainer()->get(TeleNeoWebFont::class);
-
-		// $themesService->registerThemes([$teleNeoWebFont, $magentaDefault, $magentaDark], true);
 	}
 }

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -11,47 +11,19 @@ declare(strict_types=1);
  */
 namespace OCA\NMCTheme\Listener;
 
-use OCP\IURLGenerator;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\AppFramework\Http\TemplateResponse;
-use OCA\Theming\Service\ThemesService;
-use OCA\NMCTheme\Themes\TeleNeoWebFont;
+use OCP\IURLGenerator;
 
 class BeforeTemplateRenderedListener implements IEventListener {
 	private IURLGenerator $urlGenerator;
-    private ThemesService $themesService;
-    private ThemeInjectionService $themeInjectionService;
-	private TeleNeoWebFont $teleNeoWebFont;
 
 	public function __construct(
-		IURLGenerator $urlGenerator,
-        ThemesService $themesService,
-		TeleNeoWebFont $teleNeoWebFont) {
-        $this->urlGenerator = $urlGenerator;
-		$this->themesService = $themesService;
-		$this->teleNeoWebFont = $teleNeoWebFont;
+		IURLGenerator $urlGenerator
+	) {
+		$this->urlGenerator = $urlGenerator;
 	}
-
-    /**
-	 * Inject theme header into anonymous pages without user relation
-	 *
-	 * @param string $themeId the theme ID
-	 * @param bool $plain request the :root syntax
-	 * @param string $media media query to use in the <link> element
-     */
-    private function addPublicThemeHeader(string $themeId, bool $plain = true, string $media = null) {
-		$linkToCSS = $this->urlGenerator->linkToRoute('theming.Theming.getThemeStylesheet', [
-			'themeId' => $themeId,
-			'plain' => $plain
-		]);
-		\OCP\Util::addHeader('link', [
-			'rel' => 'stylesheet',
-			'media' => $media,
-			'href' => $linkToCSS
-		]);
-	}
-
 
 	/**
 	 * The registration of Magenta themes is only done
@@ -59,16 +31,9 @@ class BeforeTemplateRenderedListener implements IEventListener {
 	 * application bootstrapping).
 	 */
 	public function handle(Event $event): void {
-		// always enable TeleNeoWebFonts if this theme is installed
-        if ($event->getResponse()->getRenderAs() === TemplateResponse::RENDER_AS_USER) {
-            $this->themesService->enableTheme($this->teleNeoWebFont);
-        } else {
-            // fix Telekom font theme always
-            $this->addPublicThemeHeader($this->teleNeoWebFont->getId());
-
-            // TODO: we can add dedicated theme css for anonymous renderings directly or
-            // as theme injection
-            \OCP\Util::addStyle("nmctheme", "nmcdefault");       
-        }
+		// you can add extra styles depending on situation
+		// if ($event->getResponse()->getRenderAs() === TemplateResponse::RENDER_AS_USER) {
+		//     \OCP\Util::addStyle("nmctheme", "some_extra_xxx");
+		// }
 	}
 }

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -11,21 +11,47 @@ declare(strict_types=1);
  */
 namespace OCA\NMCTheme\Listener;
 
+use OCP\IURLGenerator;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCA\Theming\Service\ThemesService;
 use OCA\NMCTheme\Themes\TeleNeoWebFont;
 
 class BeforeTemplateRenderedListener implements IEventListener {
-	private ThemesService $themesService;
+	private IURLGenerator $urlGenerator;
+    private ThemesService $themesService;
+    private ThemeInjectionService $themeInjectionService;
 	private TeleNeoWebFont $teleNeoWebFont;
 
 	public function __construct(
-		ThemesService $themesService,
+		IURLGenerator $urlGenerator,
+        ThemesService $themesService,
 		TeleNeoWebFont $teleNeoWebFont) {
+        $this->urlGenerator = $urlGenerator;
 		$this->themesService = $themesService;
 		$this->teleNeoWebFont = $teleNeoWebFont;
 	}
+
+    /**
+	 * Inject theme header into anonymous pages without user relation
+	 *
+	 * @param string $themeId the theme ID
+	 * @param bool $plain request the :root syntax
+	 * @param string $media media query to use in the <link> element
+     */
+    private function addPublicThemeHeader(string $themeId, bool $plain = true, string $media = null) {
+		$linkToCSS = $this->urlGenerator->linkToRoute('theming.Theming.getThemeStylesheet', [
+			'themeId' => $themeId,
+			'plain' => $plain
+		]);
+		\OCP\Util::addHeader('link', [
+			'rel' => 'stylesheet',
+			'media' => $media,
+			'href' => $linkToCSS
+		]);
+	}
+
 
 	/**
 	 * The registration of Magenta themes is only done
@@ -34,6 +60,15 @@ class BeforeTemplateRenderedListener implements IEventListener {
 	 */
 	public function handle(Event $event): void {
 		// always enable TeleNeoWebFonts if this theme is installed
-		$this->themesService->enableTheme($this->teleNeoWebFont);
+        if ($event->getResponse()->getRenderAs() === TemplateResponse::RENDER_AS_USER) {
+            $this->themesService->enableTheme($this->teleNeoWebFont);
+        } else {
+            // fix Telekom font theme always
+            $this->addPublicThemeHeader($this->teleNeoWebFont->getId());
+
+            // TODO: we can add dedicated theme css for anonymous renderings directly or
+            // as theme injection
+            \OCP\Util::addStyle("nmctheme", "nmcdefault");       
+        }
 	}
 }

--- a/lib/Service/NMCThemesService.php
+++ b/lib/Service/NMCThemesService.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 T-Systems International
+ *
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\NMCTheme\Service;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserSession;
+
+use OCA\NMCTheme\AppInfo\Application;
+
+use OCA\Theming\ITheme;
+use OCA\Theming\Service\ThemesService;
+
+use OCA\Theming\Themes\DarkHighContrastTheme;
+use OCA\Theming\Themes\DarkTheme;
+use OCA\Theming\Themes\DefaultTheme;
+use OCA\Theming\Themes\DyslexiaFont;
+use OCA\Theming\Themes\HighContrastTheme;
+use OCA\Theming\Themes\LightTheme;
+
+
+/**
+ * An alternative ThemesService with the following properties:
+ * - you can define the list of themes on boot in service registration
+ * - you can set default theme to use
+ * - you can define a set of "static" themes to always to include
+ * - if no user theme is set, the default (either configured or from registration) is used
+ */
+class NMCThemesService extends ThemesService {
+	private IUserSession $userSession;
+	private IConfig $config;
+
+	/** @var ITheme */
+	private array $defaultTheme;
+
+    /** @var ITheme[] */
+	private array $themeClasses;
+
+    /** @var string[] */
+	private array $staticThemeIds;
+
+    /** @var string[] */
+	private array $selectableThemeIds;
+
+    /** @var string[] */
+	private array $selectableFontIds;
+
+    /**
+     * Register the different types of themes on service creation
+     * 
+     * @param ITheme   $default          The registered default theme that is
+     *                                   used as fallback. It is also selectable.
+     * @param ITheme[] $selectableThemes a list of themes to select one from
+     *                                   as the user theme
+     * @param ITheme[] $staticThemes     a list of themes to always include
+     */
+	public function __construct(IUserSession $userSession,
+								IConfig $config,
+                                ITheme $default,
+                                array $selectableThemes,
+                                array $staticThemes,
+                                DefaultTheme $defaultTheme,
+								LightTheme $lightTheme,
+								DarkTheme $darkTheme,
+								HighContrastTheme $highContrastTheme,
+								DarkHighContrastTheme $darkHighContrastTheme,
+								DyslexiaFont $dyslexiaFont) {
+        parent::__construct($userSession, $config, $defaultTheme, $lightTheme, 
+                            $darkTheme, $highContrastTheme, $darkHighContrastTheme, $dyslexiaFont);
+		$this->userSession = $userSession;
+		$this->config = $config;
+
+        $mapThemeIds = function (ITheme $theme) {
+            return $theme->getId();
+        };
+        
+		// Register themes
+        $this->default = $default;
+        $this->staticThemeIds = array_map($mapThemeIds, $staticThemes);
+        $nonStaticThemes = array_merge([$default], $selectableThemes);
+        $nonStaticThemeIds = array_map($mapThemeIds, $nonStaticThemes);
+		$this->selectableThemeIds = array_map($mapThemeIds,
+                                              array_filter($selectableThemes, function(ITheme $theme) { 
+                                                return $theme->getType() == ITheme::TYPE_THEME; 
+                                              }));
+        $this->selectableFontIds = array_map($mapThemeIds,
+                                              array_filter($selectableThemes, function(ITheme $theme) { 
+                                                return $theme->getType() == ITheme::TYPE_FONT; 
+                                              }));
+        $this->themeClasses = array_merge( array_combine($nonStaticThemeIds, $nonStaticThemes),
+                                           array_combine($this->staticThemeIds, $staticThemes) );
+    }
+
+	/**
+	 * Get the list of all registered themes
+	 * 
+	 * @return ITheme[] the (id, $theme) map of registered themes
+	 */
+	public function getThemes(): array {
+		return $this->themeClasses;
+	}
+
+	/**
+	 * Get the list of all enabled themes IDs
+	 * for the logged-in user
+	 * 
+	 * @return string[]
+	 */
+	public function getEnabledThemes(): array {
+        $enforcedThemeId = $this->config->getSystemValueString('enforce_theme', '');
+        if ($enforcedThemeId !== '') {
+            // a theme enforce page setup, make sure that the theme is in selectable list
+            return array_unique(array_merge([$enforcedThemeId], $this->staticThemeIds));
+		}
+
+        $user = $this->userSession->getUser();
+		if ($user === null) {
+            // a non-enforce, anonymous page setup
+			return array_unique(array_merge( [$this->default->getId()], $this->staticThemeIds));
+		}
+
+        // a user selected page setup
+        $enabledThemeIds = json_decode($this->config->getUserValue($user->getUID(), Application::APP_ID,
+                                     'enabled-themes', '[]'));
+        $selectedThemeIds = array_intersect($this->selectableThemeIds, $enabledThemeIds);
+        if ( empty($selectedThemeIds) ) {
+            // add default to the enabled fonts adn statics (as there is no selected theme)
+            return array_unique(array_merge([$this->default->getId()], $enabledThemeIds, $this->staticThemeIds));
+        }
+
+		return array_unique(array_merge($selectedThemes, $this->staticThemeIds));
+    }
+
+	/**
+	 * Enable a theme for the logged-in user
+	 * 
+	 * @param ITheme $theme the theme to enable
+	 * @return string[] the enabled themes
+	 */
+	public function enableTheme(ITheme $theme): array {
+		$themeIds = $this->getEnabledThemes();
+
+		// If already enabled, ignore
+		if (in_array($theme->getId(), $themeIds)) {
+			return $themeIds;
+		}
+
+        // we are not in user context
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return $themeIds;            
+        }
+        
+        if (in_array($theme->getId(), $this->selectableThemeIds)) {
+            // change selection and sort it
+            $themeIds = array_unique(
+                            array_merge([$theme->getId()], 
+                                        array_diff($themeIds, $this->selectableThemeIds)));
+        } else if (in_array($theme->getId(), $this->selectableFontIds)) {
+            $themeIds = array_unique(array_merge([$theme->getId()], $themeIds));
+        } // statics are already always included
+
+        $this->config->setUserValue($user->getUID(), Application::APP_ID, 
+                                    'enabled-themes', json_encode(array_values($themeIds)));
+		return $themeIds;
+	}
+
+	/**
+	 * Disable a theme for the logged-in user
+	 * 
+	 * @param ITheme $theme the theme to disable
+	 * @return string[] the enabled themes
+	 */
+	public function disableTheme(ITheme $theme): array {
+        $themeIds = $this->getEnabledThemes();
+
+        $foundId = array_search($theme->getId(), $themeIds);
+
+		// If already disabled, ignore
+		if (!$foundId) {
+			return $themeIds;
+		}
+
+		if (in_array($theme->getId(), $this->staticThemeIds)) {
+            return $themeIds;
+        }        
+
+        // we are not in user context
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return $themeIds;            
+        }
+        
+        // we are not testing for not disabling a selectable theme as this
+        // may produces trouble with Nextcloud settings page (TODO)
+
+        array_splice($themeIds, $foundId, $foundId);
+        $this->config->setUserValue($user->getUID(), Application::APP_ID, 
+                                    'enabled-themes', json_encode(array_values($themeIds)));
+		return $themeIds;
+	}
+
+	/**
+	 * Check whether a theme is enabled or not
+	 * 
+	 * @return bool
+	 */
+	public function isEnabled(ITheme $theme): bool {
+		$themeIds = $this->getEnabledThemes();
+		return in_array($theme->getId(), $themeIds);
+	}
+
+}

--- a/lib/Service/NMCThemesService.php
+++ b/lib/Service/NMCThemesService.php
@@ -85,13 +85,13 @@ class NMCThemesService extends ThemesService {
         $this->default = $default;
         $this->staticThemeIds = array_map($mapThemeIds, $staticThemes);
         $nonStaticThemes = array_merge([$default], $selectableThemes);
-        $nonStaticThemeIds = array_map($mapThemeIds, $nonStaticThemes);
+        $nonStaticThemeIds = array_merge(['default'], array_map($mapThemeIds, $selectableThemes));
 		$this->selectableThemeIds = array_map($mapThemeIds,
-                                              array_filter($selectableThemes, function(ITheme $theme) { 
+                                              array_filter($nonStaticThemes, function(ITheme $theme) { 
                                                 return $theme->getType() == ITheme::TYPE_THEME; 
                                               }));
         $this->selectableFontIds = array_map($mapThemeIds,
-                                              array_filter($selectableThemes, function(ITheme $theme) { 
+                                              array_filter($nonStaticThemes, function(ITheme $theme) { 
                                                 return $theme->getType() == ITheme::TYPE_FONT; 
                                               }));
         $this->themeClasses = array_merge( array_combine($nonStaticThemeIds, $nonStaticThemes),

--- a/lib/Service/NMCThemesService.php
+++ b/lib/Service/NMCThemesService.php
@@ -9,22 +9,20 @@
 
 namespace OCA\NMCTheme\Service;
 
-use OCP\IConfig;
-use OCP\IUser;
-use OCP\IUserSession;
-
 use OCA\NMCTheme\AppInfo\Application;
-
 use OCA\Theming\ITheme;
+
 use OCA\Theming\Service\ThemesService;
 
 use OCA\Theming\Themes\DarkHighContrastTheme;
 use OCA\Theming\Themes\DarkTheme;
+
 use OCA\Theming\Themes\DefaultTheme;
 use OCA\Theming\Themes\DyslexiaFont;
 use OCA\Theming\Themes\HighContrastTheme;
 use OCA\Theming\Themes\LightTheme;
-
+use OCP\IConfig;
+use OCP\IUserSession;
 
 /**
  * An alternative ThemesService with the following properties:
@@ -40,67 +38,69 @@ class NMCThemesService extends ThemesService {
 	/** @var ITheme */
 	private array $defaultTheme;
 
-    /** @var ITheme[] */
+	/** @var ITheme[] */
 	private array $themeClasses;
 
-    /** @var string[] */
+	/** @var string[] */
 	private array $staticThemeIds;
 
-    /** @var string[] */
+	/** @var string[] */
 	private array $selectableThemeIds;
 
-    /** @var string[] */
+	/** @var string[] */
 	private array $selectableFontIds;
 
-    /**
-     * Register the different types of themes on service creation
-     * 
-     * @param ITheme   $default          The registered default theme that is
-     *                                   used as fallback. It is also selectable.
-     * @param ITheme[] $selectableThemes a list of themes to select one from
-     *                                   as the user theme
-     * @param ITheme[] $staticThemes     a list of themes to always include
-     */
+	/**
+	 * Register the different types of themes on service creation
+	 *
+	 * @param ITheme   $default          The registered default theme that is
+	 *                                   used as fallback. It is also selectable.
+	 * @param ITheme[] $selectableThemes a list of themes to select one from
+	 *                                   as the user theme
+	 * @param ITheme[] $staticThemes     a list of themes to always include
+	 */
 	public function __construct(IUserSession $userSession,
-								IConfig $config,
-                                ITheme $default,
-                                array $selectableThemes,
-                                array $staticThemes,
-                                DefaultTheme $defaultTheme,
-								LightTheme $lightTheme,
-								DarkTheme $darkTheme,
-								HighContrastTheme $highContrastTheme,
-								DarkHighContrastTheme $darkHighContrastTheme,
-								DyslexiaFont $dyslexiaFont) {
-        parent::__construct($userSession, $config, $defaultTheme, $lightTheme, 
-                            $darkTheme, $highContrastTheme, $darkHighContrastTheme, $dyslexiaFont);
+		IConfig $config,
+		ITheme $default,
+		array $selectableThemes,
+		array $staticThemes,
+		DefaultTheme $defaultTheme,
+		LightTheme $lightTheme,
+		DarkTheme $darkTheme,
+		HighContrastTheme $highContrastTheme,
+		DarkHighContrastTheme $darkHighContrastTheme,
+		DyslexiaFont $dyslexiaFont) {
+		parent::__construct($userSession, $config, $defaultTheme, $lightTheme,
+			$darkTheme, $highContrastTheme, $darkHighContrastTheme, $dyslexiaFont);
 		$this->userSession = $userSession;
 		$this->config = $config;
 
-        $mapThemeIds = function (ITheme $theme) {
-            return $theme->getId();
-        };
-        
+		$mapThemeIds = function (ITheme $theme) {
+			return $theme->getId();
+		};
+		
 		// Register themes
-        $this->default = $default;
-        $this->staticThemeIds = array_map($mapThemeIds, $staticThemes);
-        $nonStaticThemes = array_merge([$default], $selectableThemes);
-        $nonStaticThemeIds = array_merge(['default'], array_map($mapThemeIds, $selectableThemes));
+		$this->default = $default;
+		$this->staticThemeIds = array_map($mapThemeIds, $staticThemes); // TODO: check that default theme is not a font theme
+		// the default theme is registered dual: with identifier 'default' and with its self-given name
+		$nonStaticThemes = array_merge([$default, $default], $selectableThemes);
+		$nonStaticThemeIds = array_merge(['default', $default->getId()], array_map($mapThemeIds, $selectableThemes));
+		$this->themeClasses = array_merge(array_combine($nonStaticThemeIds, $nonStaticThemes),
+			array_combine($this->staticThemeIds, $staticThemes));
 		$this->selectableThemeIds = array_map($mapThemeIds,
-                                              array_filter($nonStaticThemes, function(ITheme $theme) { 
-                                                return $theme->getType() == ITheme::TYPE_THEME; 
-                                              }));
-        $this->selectableFontIds = array_map($mapThemeIds,
-                                              array_filter($nonStaticThemes, function(ITheme $theme) { 
-                                                return $theme->getType() == ITheme::TYPE_FONT; 
-                                              }));
-        $this->themeClasses = array_merge( array_combine($nonStaticThemeIds, $nonStaticThemes),
-                                           array_combine($this->staticThemeIds, $staticThemes) );
-    }
+			array_filter($nonStaticThemes, function (ITheme $theme) {
+				return $theme->getType() == ITheme::TYPE_THEME;
+			}));
+        $this->selectableThemeIds[0] = 'default'; // this is duplicate getId() value, so first is inteneded as default   
+		$this->selectableFontIds = array_map($mapThemeIds,
+			array_filter($nonStaticThemes, function (ITheme $theme) {
+				return $theme->getType() == ITheme::TYPE_FONT;
+			}));
+	}
 
 	/**
 	 * Get the list of all registered themes
-	 * 
+	 *
 	 * @return ITheme[] the (id, $theme) map of registered themes
 	 */
 	public function getThemes(): array {
@@ -110,37 +110,38 @@ class NMCThemesService extends ThemesService {
 	/**
 	 * Get the list of all enabled themes IDs
 	 * for the logged-in user
-	 * 
+	 *
 	 * @return string[]
 	 */
 	public function getEnabledThemes(): array {
-        $enforcedThemeId = $this->config->getSystemValueString('enforce_theme', '');
-        if ($enforcedThemeId !== '') {
-            // a theme enforce page setup, make sure that the theme is in selectable list
-            return array_unique(array_merge([$enforcedThemeId], $this->staticThemeIds));
+		$enforcedThemeId = $this->config->getSystemValueString('enforce_theme', '');
+		if ($enforcedThemeId !== '') {
+			// a theme enforce page setup, make sure that the theme is in selectable list
+			return array_unique(array_merge([$enforcedThemeId], $this->staticThemeIds));
 		}
 
-        $user = $this->userSession->getUser();
+		$user = $this->userSession->getUser();
 		if ($user === null) {
-            // a non-enforce, anonymous page setup
-			return array_unique(array_merge( [$this->default->getId()], $this->staticThemeIds));
+			// a non-enforce, anonymous page setup
+			return array_unique(array_merge(['default'], $this->staticThemeIds));
 		}
 
-        // a user selected page setup
-        $enabledThemeIds = json_decode($this->config->getUserValue($user->getUID(), Application::APP_ID,
-                                     'enabled-themes', '[]'));
-        $selectedThemeIds = array_intersect($this->selectableThemeIds, $enabledThemeIds);
-        if ( empty($selectedThemeIds) ) {
-            // add default to the enabled fonts adn statics (as there is no selected theme)
-            return array_unique(array_merge([$this->default->getId()], $enabledThemeIds, $this->staticThemeIds));
-        }
+		// a user selected page setup
+        $userValues = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'enabled-themes', '[]');
+		$enabledThemeIds = json_decode($userValues);
+		$selectedThemeIds = array_intersect($this->selectableThemeIds, $enabledThemeIds);
+        $selectedFontIds = array_intersect($this->selectableFontIds, $enabledThemeIds);
+		if (empty($selectedThemeIds)) {
+			// add default to the enabled fonts adn statics (as there is no selected theme)
+			return array_unique(array_merge(['default'], $selectedFontIds, $this->staticThemeIds));
+		}
 
-		return array_unique(array_merge($selectedThemes, $this->staticThemeIds));
-    }
+		return array_unique(array_merge($selectedThemeIds, $selectedFontIds, $this->staticThemeIds));
+	}
 
 	/**
 	 * Enable a theme for the logged-in user
-	 * 
+	 *
 	 * @param ITheme $theme the theme to enable
 	 * @return string[] the enabled themes
 	 */
@@ -152,36 +153,36 @@ class NMCThemesService extends ThemesService {
 			return $themeIds;
 		}
 
-        // we are not in user context
-        $user = $this->userSession->getUser();
-        if ($user === null) {
-            return $themeIds;            
-        }
-        
-        if (in_array($theme->getId(), $this->selectableThemeIds)) {
-            // change selection and sort it
-            $themeIds = array_unique(
-                            array_merge([$theme->getId()], 
-                                        array_diff($themeIds, $this->selectableThemeIds)));
-        } else if (in_array($theme->getId(), $this->selectableFontIds)) {
-            $themeIds = array_unique(array_merge([$theme->getId()], $themeIds));
-        } // statics are already always included
+		// we are not in user context
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return $themeIds;
+		}
+		
+		if (in_array($theme->getId(), $this->selectableThemeIds)) {
+			// change selection and sort it
+			$themeIds = array_unique(
+				array_merge([$theme->getId()],
+					array_diff($themeIds, $this->selectableThemeIds)));
+		} elseif (in_array($theme->getId(), $this->selectableFontIds)) {
+			$themeIds = array_unique(array_merge([$theme->getId()], $themeIds));
+		} // statics are already always included
 
-        $this->config->setUserValue($user->getUID(), Application::APP_ID, 
-                                    'enabled-themes', json_encode(array_values($themeIds)));
+		$this->config->setUserValue($user->getUID(), Application::APP_ID,
+			'enabled-themes', json_encode(array_values($themeIds)));
 		return $themeIds;
 	}
 
 	/**
 	 * Disable a theme for the logged-in user
-	 * 
+	 *
 	 * @param ITheme $theme the theme to disable
 	 * @return string[] the enabled themes
 	 */
 	public function disableTheme(ITheme $theme): array {
-        $themeIds = $this->getEnabledThemes();
+		$themeIds = $this->getEnabledThemes();
 
-        $foundId = array_search($theme->getId(), $themeIds);
+		$foundId = array_search($theme->getId(), $themeIds);
 
 		// If already disabled, ignore
 		if (!$foundId) {
@@ -189,27 +190,27 @@ class NMCThemesService extends ThemesService {
 		}
 
 		if (in_array($theme->getId(), $this->staticThemeIds)) {
-            return $themeIds;
-        }        
+			return $themeIds;
+		}
 
-        // we are not in user context
-        $user = $this->userSession->getUser();
-        if ($user === null) {
-            return $themeIds;            
-        }
-        
-        // we are not testing for not disabling a selectable theme as this
-        // may produces trouble with Nextcloud settings page (TODO)
+		// we are not in user context
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return $themeIds;
+		}
+		
+		// we are not testing for not disabling a selectable theme as this
+		// may produces trouble with Nextcloud settings page (TODO)
 
-        array_splice($themeIds, $foundId, $foundId);
-        $this->config->setUserValue($user->getUID(), Application::APP_ID, 
-                                    'enabled-themes', json_encode(array_values($themeIds)));
+		array_splice($themeIds, $foundId, $foundId);
+		$this->config->setUserValue($user->getUID(), Application::APP_ID,
+			'enabled-themes', json_encode(array_values($themeIds)));
 		return $themeIds;
 	}
 
 	/**
 	 * Check whether a theme is enabled or not
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function isEnabled(ITheme $theme): bool {

--- a/lib/Service/NMCThemesService.php
+++ b/lib/Service/NMCThemesService.php
@@ -91,7 +91,7 @@ class NMCThemesService extends ThemesService {
 			array_filter($nonStaticThemes, function (ITheme $theme) {
 				return $theme->getType() == ITheme::TYPE_THEME;
 			}));
-        $this->selectableThemeIds[0] = 'default'; // this is duplicate getId() value, so first is inteneded as default   
+		$this->selectableThemeIds[0] = 'default'; // this is duplicate getId() value, so first is inteneded as default
 		$this->selectableFontIds = array_map($mapThemeIds,
 			array_filter($nonStaticThemes, function (ITheme $theme) {
 				return $theme->getType() == ITheme::TYPE_FONT;
@@ -127,10 +127,10 @@ class NMCThemesService extends ThemesService {
 		}
 
 		// a user selected page setup
-        $userValues = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'enabled-themes', '[]');
+		$userValues = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'enabled-themes', '[]');
 		$enabledThemeIds = json_decode($userValues);
 		$selectedThemeIds = array_intersect($this->selectableThemeIds, $enabledThemeIds);
-        $selectedFontIds = array_intersect($this->selectableFontIds, $enabledThemeIds);
+		$selectedFontIds = array_intersect($this->selectableFontIds, $enabledThemeIds);
 		if (empty($selectedThemeIds)) {
 			// add default to the enabled fonts adn statics (as there is no selected theme)
 			return array_unique(array_merge(['default'], $selectedFontIds, $this->staticThemeIds));

--- a/lib/Themes/Magenta.php
+++ b/lib/Themes/Magenta.php
@@ -11,15 +11,19 @@ declare(strict_types=1);
 namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
+use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class Magenta implements ITheme {
-	public IURLGenerator $urlGenerator;
-	public IL10N $l;
+	private IAppManager $appManager;
+	private IURLGenerator $urlGenerator;
+	private IL10N $l;
 
-	public function __construct(IURLGenerator $urlGenerator,
-								IL10N $l) {
+	public function __construct(IAppManager $appManager,
+		IURLGenerator $urlGenerator,
+		IL10N $l) {
+		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;
 		$this->l = $l;
 	}
@@ -53,12 +57,12 @@ class Magenta implements ITheme {
 	}
 
 	public function getCustomCss(): string {
-		$telekomTokens = $this->urlGenerator->linkTo('nmctheme', 'css/telekom-design-tokens.all.css');
+		$telekomVariables = $this->urlGenerator->linkTo('nmctheme', 'css/telekom-design-tokens.all.css');
 		$themeVariables = $this->urlGenerator->linkTo('nmctheme', 'css/nmcdefault.css');
-		
+
 		return "
-            @import url('$telekomTokens');
-            @import url('$themeVariables');        
-        ";
+        @import url('{$telekomVariables}');
+        @import url('{$themeVariables}');        
+    ";
 	}
 }

--- a/lib/Themes/MagentaDark.php
+++ b/lib/Themes/MagentaDark.php
@@ -11,19 +11,23 @@ declare(strict_types=1);
 namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
+use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class MagentaDark implements ITheme {
-	public IURLGenerator $urlGenerator;
-	public IL10N $l;
+	private IAppManager $appManager;
+	private IURLGenerator $urlGenerator;
+	private IL10N $l;
 
-	public function __construct(IURLGenerator $urlGenerator,
-								IL10N $l) {
+	public function __construct(IAppManager $appManager,
+		IURLGenerator $urlGenerator,
+		IL10N $l) {
+		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;
 		$this->l = $l;
 	}
-
+	
 	public function getId(): string {
 		return 'magenta25dark';
 	}
@@ -53,12 +57,14 @@ class MagentaDark implements ITheme {
 	}
 
 	public function getCustomCss(): string {
-		$telekomTokens = $this->urlGenerator->linkTo('nmctheme', 'css/telekom-design-tokens.all.css');
-		$themeVariables = $this->urlGenerator->linkTo('nmctheme', 'css/nmcdark.css');
-		
+		$telekomVariables =
+			$this->urlGenerator->linkTo('nmctheme', 'css/telekom-design-tokens.all.css');
+		$themeVariables =
+			$this->urlGenerator->linkTo('nmctheme', 'css/nmcdark.css');
+
 		return "
-            @import url('$telekomTokens');
-            @import url('$themeVariables');        
+            @import url('{$telekomVariables}');
+            @import url('{$themeVariables}');        
         ";
 	}
 }

--- a/lib/Themes/TeleNeoWebFont.php
+++ b/lib/Themes/TeleNeoWebFont.php
@@ -19,15 +19,15 @@ namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
 use OCP\IL10N;
-use OCP\IURLGenerator;
+use OCP\App\IAppManager;
 
 class TeleNeoWebFont implements ITheme {
-	public IURLGenerator $urlGenerator;
-	public IL10N $l;
+	private IAppManager $appManager;
+	private IL10N $l;
 
-	public function __construct(IURLGenerator $urlGenerator,
+	public function __construct(IAppManager $appManager,
 								IL10N $l) {
-		$this->urlGenerator = $urlGenerator;
+        $this->appManager = $appManager;
 		$this->l = $l;
 	}
 
@@ -61,105 +61,105 @@ class TeleNeoWebFont implements ITheme {
 	}
 
 	public function getCustomCss(): string {
-		// TODO: may reduce the delivered fonts to only those actually used in the design
-		$fontPrefixUrl = $this->urlGenerator->linkTo('nmctheme', 'fonts/TeleNeoWeb');
+		$fontPrefixUrl = $this->appManager->getAppWebPath("nmctheme") . "/fonts/TeleNeoWeb/TeleNeoWeb"; 
 
+		// TODO: may reduce the delivered fonts to only those actually used in the design
 		return "
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 900;
             font-style: normal;
-            src: url('${fontPrefixUrl}-Ultra.eot');
-            src: url('${fontPrefixUrl}-Ultra.woff') format('woff'),
-                 url('${fontPrefixUrl}-Ultra.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-Ultra.eot');
+            src: url('{$fontPrefixUrl}-Ultra.woff') format('woff'),
+                 url('{$fontPrefixUrl}-Ultra.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 900;
             font-style: italic;
-            src: url('${fontPrefixUrl}-UltraItalic.eot');
-            src: url('${fontPrefixUrl}-UltraItalic.woff') format('woff'),
-                 url('${fontPrefixUrl}-UltraItalic.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-UltraItalic.eot');
+            src: url('{$fontPrefixUrl}-UltraItalic.woff') format('woff'),
+                 url('{$fontPrefixUrl}-UltraItalic.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 800;
             font-style: normal;
-            src: url('${fontPrefixUrl}-ExtraBold.eot');
-            src: url('${fontPrefixUrl}-ExtraBold.woff') format('woff'),
-                 url('${fontPrefixUrl}-ExtraBold.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-ExtraBold.eot');
+            src: url('{$fontPrefixUrl}-ExtraBold.woff') format('woff'),
+                 url('{$fontPrefixUrl}-ExtraBold.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 800;
             font-style: italic;
-            src: url('${fontPrefixUrl}-ExtraBoldItalic.eot');
-            src: url('${fontPrefixUrl}-ExtraBoldItalic.woff') format('woff'),
-                 url('${fontPrefixUrl}-ExtraBoldItalic.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-ExtraBoldItalic.eot');
+            src: url('{$fontPrefixUrl}-ExtraBoldItalic.woff') format('woff'),
+                 url('{$fontPrefixUrl}-ExtraBoldItalic.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 700;
             font-style: normal;
-            src: url('${fontPrefixUrl}-Bold.eot');
-            src: url('${fontPrefixUrl}-Bold.woff') format('woff'),
-                 url('${fontPrefixUrl}-Bold.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-Bold.eot');
+            src: url('{$fontPrefixUrl}-Bold.woff') format('woff'),
+                 url('{$fontPrefixUrl}-Bold.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 700;
             font-style: italic;
-            src: url('${fontPrefixUrl}-BoldItalic.eot');
-            src: url('${fontPrefixUrl}-BoldItalic.woff') format('woff'),
-                 url('${fontPrefixUrl}-BoldItalic.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-BoldItalic.eot');
+            src: url('{$fontPrefixUrl}-BoldItalic.woff') format('woff'),
+                 url('{$fontPrefixUrl}-BoldItalic.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 500;
             font-style: normal;
-            src: url('${fontPrefixUrl}-Medium.eot');
-            src: url('${fontPrefixUrl}-Medium.woff') format('woff'),
-                 url('${fontPrefixUrl}-Medium.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-Medium.eot');
+            src: url('{$fontPrefixUrl}-Medium.woff') format('woff'),
+                 url('{$fontPrefixUrl}-Medium.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 500;
             font-style: italic;
-            src: url('${fontPrefixUrl}-MediumItalic.eot');
-            src: url('${fontPrefixUrl}-MediumItalic.woff') format('woff'),
-                 url('${fontPrefixUrl}-MediumItalic.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-MediumItalic.eot');
+            src: url('{$fontPrefixUrl}-MediumItalic.woff') format('woff'),
+                 url('{$fontPrefixUrl}-MediumItalic.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 400;
             font-style: normal;
-            src: url('${fontPrefixUrl}-Regular.eot');
-            src: url('${fontPrefixUrl}-Regular.woff') format('woff'),
-              url('${fontPrefixUrl}-Regular.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-Regular.eot');
+            src: url('{$fontPrefixUrl}-Regular.woff') format('woff'),
+              url('{$fontPrefixUrl}-Regular.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 400;
             font-style: italic;
-            src: url('${fontPrefixUrl}-RegularItalic.eot');
-            src: url('${fontPrefixUrl}-RegularItalic.woff') format('woff'),
-              url('${fontPrefixUrl}-RegularItalic.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-RegularItalic.eot');
+            src: url('{$fontPrefixUrl}-RegularItalic.woff') format('woff'),
+              url('{$fontPrefixUrl}-RegularItalic.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 200;
             font-style: normal;
-            src: url('${fontPrefixUrl}-Thin.eot');
-            src: url('${fontPrefixUrl}-Thin.woff') format('woff'),
-              url('${fontPrefixUrl}-Thin.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-Thin.eot');
+            src: url('{$fontPrefixUrl}-Thin.woff') format('woff'),
+              url('{$fontPrefixUrl}-Thin.woff2') format('woff2');
           }
           @font-face {
             font-family: 'TeleNeoWeb';
             font-weight: 200;
             font-style: italic;
-            src: url('${fontPrefixUrl}-ThinItalic.eot');
-            src: url('${fontPrefixUrl}-ThinItalic.woff') format('woff'),
-              url('${fontPrefixUrl}-ThinItalic.woff2') format('woff2');
+            src: url('{$fontPrefixUrl}-ThinItalic.eot');
+            src: url('{$fontPrefixUrl}-ThinItalic.woff') format('woff'),
+              url('{$fontPrefixUrl}-ThinItalic.woff2') format('woff2');
           }";
 	}
 }

--- a/lib/Themes/TeleNeoWebFont.php
+++ b/lib/Themes/TeleNeoWebFont.php
@@ -18,16 +18,20 @@ declare(strict_types=1);
 namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
-use OCP\IL10N;
 use OCP\App\IAppManager;
+use OCP\IL10N;
+use OCP\IURLGenerator;
 
 class TeleNeoWebFont implements ITheme {
 	private IAppManager $appManager;
+	private IURLGenerator $urlGenerator;
 	private IL10N $l;
 
 	public function __construct(IAppManager $appManager,
-								IL10N $l) {
-        $this->appManager = $appManager;
+		IURLGenerator $urlGenerator,
+		IL10N $l) {
+		$this->appManager = $appManager;
+		$this->urlGenerator = $urlGenerator;
 		$this->l = $l;
 	}
 
@@ -61,7 +65,8 @@ class TeleNeoWebFont implements ITheme {
 	}
 
 	public function getCustomCss(): string {
-		$fontPrefixUrl = $this->appManager->getAppWebPath("nmctheme") . "/fonts/TeleNeoWeb/TeleNeoWeb"; 
+		// avoid existence check of each file
+		$fontPrefixUrl = $this->appManager->getAppWebPath("nmctheme") . "/fonts/TeleNeoWeb/TeleNeoWeb";
 
 		// TODO: may reduce the delivered fonts to only those actually used in the design
 		return "

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,5 +2,6 @@
 
 require_once __DIR__ . '/../../../tests/bootstrap.php';
 
+\OC::$composerAutoloader->addPsr4('OCA\\NMCTheme\\Tests\\', dirname(__FILE__) . '/unit/', true);
 \OC_App::loadApp('nmctheme');
 OC_Hook::clear();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once __DIR__ . '/../../../tests/bootstrap.php';
+
+\OC_App::loadApp('nmctheme');
+OC_Hook::clear();

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="bootstrap.php" convertDeprecationsToExceptions="true">
+	<testsuite name='nmctheme app tests'>
+		<directory>unit</directory>
+	</testsuite>
+</phpunit>

--- a/tests/unit/Service/NMCThemesServiceTest.php
+++ b/tests/unit/Service/NMCThemesServiceTest.php
@@ -28,11 +28,11 @@ class NMCThemesServiceTest extends NMCThemesServiceTestCase {
 		$this->assertEquals($this->staticThemes[2], $themeClasses['static2']);
 	}
 
-    /**
-     * Test situation is
-     * - anonymous page, no login
-     * - no enforced theme in server config
-     */
+	/**
+	 * Test situation is
+	 * - anonymous page, no login
+	 * - no enforced theme in server config
+	 */
 	public function testAnonymousDefault() {
 		$this->config->expects($this->never())->method('getUserValue');
 		$this->userSession->expects($this->once())->method('getUser')->willReturn(null);
@@ -48,11 +48,11 @@ class NMCThemesServiceTest extends NMCThemesServiceTestCase {
  
 	}
 
-    /**
-     * Test situation is
-     * - anonymous page, no login
-     * - enforced theme in server config
-     */
+	/**
+	 * Test situation is
+	 * - anonymous page, no login
+	 * - enforced theme in server config
+	 */
 	public function testAnonymousDefaultEnforced() {
 		$this->config->expects($this->never())->method('getUserValue');
 		$this->userSession->expects($this->never())->method('getUser');
@@ -68,12 +68,12 @@ class NMCThemesServiceTest extends NMCThemesServiceTestCase {
 		$this->assertContains('static2', $enabledThemes);
 	}
 
-    /**
-     * Test situation is
-     * - user logged in
-     * - enforced theme in server config
-     * - enforcement uses the real name of the default theme
-     */
+	/**
+	 * Test situation is
+	 * - user logged in
+	 * - enforced theme in server config
+	 * - enforcement uses the real name of the default theme
+	 */
 	public function testUserDefaultEnforced() {
 		$this->config->expects($this->never())->method('getUserValue');
 		$this->userSession->expects($this->never())->method('getUser');
@@ -89,11 +89,11 @@ class NMCThemesServiceTest extends NMCThemesServiceTestCase {
 		$this->assertContains('static2', $enabledThemes);
 	}
 
-    /**
-     * Test situation is
-     * - user logged in
-     * - user has no perferences set yet for themes
-     */
+	/**
+	 * Test situation is
+	 * - user logged in
+	 * - user has no perferences set yet for themes
+	 */
 	public function testUnthemedUser() {
 		$this->config->expects($this->any())->method('getUserValue')->willReturn('[]');
 		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
@@ -101,26 +101,26 @@ class NMCThemesServiceTest extends NMCThemesServiceTestCase {
 		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
 
 		$enabledThemes = $this->themesService->getEnabledThemes();
-        $this->assertCount(4, $enabledThemes);
+		$this->assertCount(4, $enabledThemes);
 		$this->assertContains('default', $enabledThemes);
 		$this->assertContains('teleneoweb', $enabledThemes);
 		$this->assertContains('static1', $enabledThemes);
 		$this->assertContains('static2', $enabledThemes);
 	}
 
-    /**
-     * Test situation is
-     * - user logged in
-     * - user has only non-existing preferences set
-     */
-    public function testUserObsoleteOnly() {
+	/**
+	 * Test situation is
+	 * - user logged in
+	 * - user has only non-existing preferences set
+	 */
+	public function testUserObsoleteOnly() {
 		$this->config->expects($this->any())->method('getUserValue')->willReturn('["blackbeard","sparrow"]');
 		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
 		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
 
 		$enabledThemes = $this->themesService->getEnabledThemes();
-        $this->assertCount(4, $enabledThemes);
+		$this->assertCount(4, $enabledThemes);
 		$this->assertContains('default', $enabledThemes);
 		$this->assertContains('teleneoweb', $enabledThemes);
 		$this->assertContains('static1', $enabledThemes);
@@ -128,49 +128,49 @@ class NMCThemesServiceTest extends NMCThemesServiceTestCase {
 	}
 
 
-    /**
-     * Test situation is
-     * - user logged in
-     * - user has a mix of existing and non-existing set, but none is a selectable theme
-     *   (default is then the main theme to use)
-     */
+	/**
+	 * Test situation is
+	 * - user logged in
+	 * - user has a mix of existing and non-existing set, but none is a selectable theme
+	 *   (default is then the main theme to use)
+	 */
 	public function testObsoleteAndActualNoUserThemeSelected() {
 		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
 		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
 		$this->config->expects($this->any())->method('getUserValue')
-            ->with($this->equalTo('0815user'), $this->equalTo('nmctheme'),
-                    $this->equalTo('enabled-themes'), $this->equalTo('[]'))
-            ->willReturn('["darkforce","selectable1","teleneoweb","bluebay","static1"]');
+			->with($this->equalTo('0815user'), $this->equalTo('nmctheme'),
+				$this->equalTo('enabled-themes'), $this->equalTo('[]'))
+			->willReturn('["darkforce","selectable1","teleneoweb","bluebay","static1"]');
 
 		$enabledThemes = $this->themesService->getEnabledThemes();
-        $this->assertCount(5, $enabledThemes);
-        $this->assertContains('default', $enabledThemes);
-        $this->assertContains('selectable1', $enabledThemes);
+		$this->assertCount(5, $enabledThemes);
+		$this->assertContains('default', $enabledThemes);
+		$this->assertContains('selectable1', $enabledThemes);
 		$this->assertContains('teleneoweb', $enabledThemes);
 		$this->assertContains('static1', $enabledThemes);
 		$this->assertContains('static2', $enabledThemes);
 	}
 
-    /**
-     * Test situation is
-     * - user logged in
-     * - user has a mix of existing and non-existing set
-     * - selection contains a main theme
-     */
+	/**
+	 * Test situation is
+	 * - user logged in
+	 * - user has a mix of existing and non-existing set
+	 * - selection contains a main theme
+	 */
 	public function testObsoleteAndActualUserThemeSelected() {
 		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
 		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
 		$this->config->expects($this->any())->method('getUserValue')
-            ->with($this->equalTo('0815user'), $this->equalTo('nmctheme'),
-                    $this->equalTo('enabled-themes'), $this->equalTo('[]'))
-            ->willReturn('["selectable2","selectable1","teleneoweb","bluebay","static1"]');
+			->with($this->equalTo('0815user'), $this->equalTo('nmctheme'),
+				$this->equalTo('enabled-themes'), $this->equalTo('[]'))
+			->willReturn('["selectable2","selectable1","teleneoweb","bluebay","static1"]');
 
 		$enabledThemes = $this->themesService->getEnabledThemes();
-        $this->assertCount(5, $enabledThemes);
-        $this->assertContains('selectable1', $enabledThemes);
-        $this->assertContains('selectable2', $enabledThemes);
+		$this->assertCount(5, $enabledThemes);
+		$this->assertContains('selectable1', $enabledThemes);
+		$this->assertContains('selectable2', $enabledThemes);
 		$this->assertContains('teleneoweb', $enabledThemes);
 		$this->assertContains('static1', $enabledThemes);
 		$this->assertContains('static2', $enabledThemes);

--- a/tests/unit/Service/NMCThemesServiceTest.php
+++ b/tests/unit/Service/NMCThemesServiceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\NMCTheme\Tests\Service;
+
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\App\IAppManager;
+
+use PHPUnit\Framework\TestCase;
+
+use OCA\NMCTheme\AppInfo\Application;
+use OCA\NMCTheme\Service\NMCThemesService;
+use OCA\NMCTheme\Themes\TeleNeoWebFont;
+use OCA\NMCTheme\Themes\Magenta;
+use OCA\NMCTheme\Themes\MagentaDark;
+
+use OCA\Theming\Service\ThemesService;
+use OCA\Theming\ThemingDefaults;
+use OCA\Theming\ITheme;
+
+use OCA\Theming\Themes\DarkHighContrastTheme;
+use OCA\Theming\Themes\DarkTheme;
+use OCA\Theming\Themes\DefaultTheme;
+use OCA\Theming\Themes\DyslexiaFont;
+use OCA\Theming\Themes\HighContrastTheme;
+use OCA\Theming\Themes\LightTheme;
+
+class NMCThemesServiceTest extends TestCase
+{
+    /** @var ThemesService */
+    private $themesService;
+
+    /** @var IUserSession */
+    private $userSession;
+    /** @var IConfig */
+    private $config;
+    /** @var ThemingDefaults */
+    private $themingDefaults;
+    /** @var AppManager */
+    private $appManager;
+
+    /** @var ITheme */
+    private $defaultTheme;
+    /** @var ITheme[] */
+    private $selectableThemes;
+    /** @var ITheme[] */
+    private $staticThemes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->user = $this->createMock(IUser::class);
+        $this->config = $this->createMock(IConfig::class);
+        $this->themingDefaults = $this->createMock(ThemingDefaults::class);
+
+        $this->themingDefaults->expects($this->any())
+            ->method('getColorPrimary')
+            ->willReturn('#0082c9');
+
+        $this->themingDefaults->expects($this->any())
+            ->method('getDefaultColorPrimary')
+            ->willReturn('#0082c9');
+
+        $this->appManager = $this->createMock(IAppManager::class);
+        //$this->appManager->expects($this->once())
+        //    ->method('getAppWebPath')
+        //    ->willReturn('/strangeapps/nmctheme/');
+
+        // prpeare a complex theme setup
+        $app = new \OCP\AppFramework\App(Application::APP_ID);
+        $this->defaultTheme = $app->getContainer()->get(Magenta::class);
+        $selectable1 = $this->createMock(ITheme::class);
+        $selectable1->expects($this->any())->method('getId')->willReturn("selectable1");
+        $selectable1->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_FONT);
+        $selectable2 = $this->createMock(ITheme::class);
+        $selectable2->expects($this->any())->method('getId')->willReturn("selectable2");
+        $selectable2->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_THEME);
+        $this->selectableThemes = [ $app->getContainer()->get(MagentaDark::class),
+                                    $selectable1, $selectable2 ];
+
+        $static1 = $this->createMock(ITheme::class);
+        $static1->expects($this->any())->method('getId')->willReturn("static1");
+        $static1->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_FONT);
+        $static2 = $this->createMock(ITheme::class);
+        $static2->expects($this->any())->method('getId')->willReturn("static2");
+        $static2->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_THEME);                            
+        $this->staticThemes = [ $app->getContainer()->get(TeleNeoWebFont::class),
+                                $static1, $static2 ];
+
+        $this->themesService = new NMCThemesService(
+            $this->userSession,
+            $this->config,
+            $this->defaultTheme,
+            $this->selectableThemes,
+            $this->staticThemes,
+            $app->getContainer()->get(DefaultTheme::class),
+            $app->getContainer()->get(LightTheme::class),
+            $app->getContainer()->get(DarkTheme::class),
+            $app->getContainer()->get(HighContrastTheme::class),
+            $app->getContainer()->get(DarkHighContrastTheme::class),
+            $app->getContainer()->get(DyslexiaFont::class)
+        );
+    }
+
+    function testClassMapping() {
+        $themeClasses = $this->themesService->getThemes();
+        $this->assertCount(7,$themeClasses);
+        $this->assertArrayHasKey('magenta25', $themeClasses);
+        $this->assertArrayHasKey('magenta25dark', $themeClasses);
+        $this->assertArrayHasKey('selectable1', $themeClasses);
+        $this->assertArrayHasKey('selectable2', $themeClasses);
+        $this->assertArrayHasKey('teleneoweb', $themeClasses);
+        $this->assertArrayHasKey('static1', $themeClasses);
+        $this->assertArrayHasKey('static2', $themeClasses);
+    }
+
+    function testAnonymousDefault() {
+        $this->config->expects($this->never())->method('getUserValue');
+        $this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
+        $this->userSession->expects($this->once())->method('getUser')->willReturn(null);        
+    
+        $enabledThemes = $this->themesService->getEnabledThemes();
+    }
+
+    function testUnthemedUser() {
+        $this->config->expects($this->any())->method('getUserValue')->willReturn('[]');
+        $this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
+        $this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);        
+        $this->user->expects($this->any())->method('getUID')->willReturn('0815user');
+
+        $enabledThemes = $this->themesService->getEnabledThemes();
+    }
+
+
+}

--- a/tests/unit/Service/NMCThemesServiceTest.php
+++ b/tests/unit/Service/NMCThemesServiceTest.php
@@ -4,139 +4,176 @@ declare(strict_types=1);
 
 namespace OCA\NMCTheme\Tests\Service;
 
-use OCP\IConfig;
-use OCP\IUser;
-use OCP\IUserSession;
-use OCP\IL10N;
-use OCP\IURLGenerator;
-use OCP\App\IAppManager;
+class NMCThemesServiceTest extends NMCThemesServiceTestCase {
+	public function testClassMapping() {
+		$themeClasses = $this->themesService->getThemes();
+		$this->assertCount(8, $themeClasses);
+		// the default theme is not registered by own name
+		// check key->class mapping
+		$this->assertArrayHasKey('default', $themeClasses);
+		$this->assertEquals($this->defaultTheme, $themeClasses['default']);
+		$this->assertArrayHasKey('magenta25', $themeClasses, "No original name registration for default");
+		$this->assertEquals($this->defaultTheme, $themeClasses['magenta25']);
+		$this->assertArrayHasKey('magenta25dark', $themeClasses);
+		$this->assertEquals($this->selectableThemes[0], $themeClasses['magenta25dark']);
+		$this->assertArrayHasKey('selectable1', $themeClasses);
+		$this->assertEquals($this->selectableThemes[1], $themeClasses['selectable1']);
+		$this->assertArrayHasKey('selectable2', $themeClasses);
+		$this->assertEquals($this->selectableThemes[2], $themeClasses['selectable2']);
+		$this->assertArrayHasKey('teleneoweb', $themeClasses);
+		$this->assertEquals($this->staticThemes[0], $themeClasses['teleneoweb']);
+		$this->assertArrayHasKey('static1', $themeClasses);
+		$this->assertEquals($this->staticThemes[1], $themeClasses['static1']);
+		$this->assertArrayHasKey('static2', $themeClasses);
+		$this->assertEquals($this->staticThemes[2], $themeClasses['static2']);
+	}
 
-use PHPUnit\Framework\TestCase;
+    /**
+     * Test situation is
+     * - anonymous page, no login
+     * - no enforced theme in server config
+     */
+	public function testAnonymousDefault() {
+		$this->config->expects($this->never())->method('getUserValue');
+		$this->userSession->expects($this->once())->method('getUser')->willReturn(null);
+		$this->config->expects($this->once())->method('getSystemValueString')
+			->with($this->equalTo('enforce_theme'), $this->equalTo(''))->willReturn('');
+	
+		$enabledThemes = $this->themesService->getEnabledThemes();
+		$this->assertCount(4, $enabledThemes);
+		$this->assertContains('default', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+ 
+	}
 
-use OCA\NMCTheme\AppInfo\Application;
-use OCA\NMCTheme\Service\NMCThemesService;
-use OCA\NMCTheme\Themes\TeleNeoWebFont;
-use OCA\NMCTheme\Themes\Magenta;
-use OCA\NMCTheme\Themes\MagentaDark;
+    /**
+     * Test situation is
+     * - anonymous page, no login
+     * - enforced theme in server config
+     */
+	public function testAnonymousDefaultEnforced() {
+		$this->config->expects($this->never())->method('getUserValue');
+		$this->userSession->expects($this->never())->method('getUser');
+		$this->config->expects($this->once())->method('getSystemValueString')
+			->with($this->equalTo('enforce_theme'), $this->equalTo(''))->willReturn('selectable1');
+	
+		$enabledThemes = $this->themesService->getEnabledThemes();
+		$this->assertCount(4, $enabledThemes);
+		$this->assertNotContains('default', $enabledThemes);
+		$this->assertContains('selectable1', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+	}
 
-use OCA\Theming\Service\ThemesService;
-use OCA\Theming\ThemingDefaults;
-use OCA\Theming\ITheme;
+    /**
+     * Test situation is
+     * - user logged in
+     * - enforced theme in server config
+     * - enforcement uses the real name of the default theme
+     */
+	public function testUserDefaultEnforced() {
+		$this->config->expects($this->never())->method('getUserValue');
+		$this->userSession->expects($this->never())->method('getUser');
+		$this->config->expects($this->once())->method('getSystemValueString')
+			->with($this->equalTo('enforce_theme'), $this->equalTo(''))->willReturn('magenta25');
+	
+		$enabledThemes = $this->themesService->getEnabledThemes();
+		$this->assertCount(4, $enabledThemes);
+		$this->assertNotContains('default', $enabledThemes);
+		$this->assertContains('magenta25', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+	}
 
-use OCA\Theming\Themes\DarkHighContrastTheme;
-use OCA\Theming\Themes\DarkTheme;
-use OCA\Theming\Themes\DefaultTheme;
-use OCA\Theming\Themes\DyslexiaFont;
-use OCA\Theming\Themes\HighContrastTheme;
-use OCA\Theming\Themes\LightTheme;
+    /**
+     * Test situation is
+     * - user logged in
+     * - user has no perferences set yet for themes
+     */
+	public function testUnthemedUser() {
+		$this->config->expects($this->any())->method('getUserValue')->willReturn('[]');
+		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
+		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
 
-class NMCThemesServiceTest extends TestCase
-{
-    /** @var ThemesService */
-    private $themesService;
+		$enabledThemes = $this->themesService->getEnabledThemes();
+        $this->assertCount(4, $enabledThemes);
+		$this->assertContains('default', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+	}
 
-    /** @var IUserSession */
-    private $userSession;
-    /** @var IConfig */
-    private $config;
-    /** @var ThemingDefaults */
-    private $themingDefaults;
-    /** @var AppManager */
-    private $appManager;
+    /**
+     * Test situation is
+     * - user logged in
+     * - user has only non-existing preferences set
+     */
+    public function testUserObsoleteOnly() {
+		$this->config->expects($this->any())->method('getUserValue')->willReturn('["blackbeard","sparrow"]');
+		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
+		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
 
-    /** @var ITheme */
-    private $defaultTheme;
-    /** @var ITheme[] */
-    private $selectableThemes;
-    /** @var ITheme[] */
-    private $staticThemes;
+		$enabledThemes = $this->themesService->getEnabledThemes();
+        $this->assertCount(4, $enabledThemes);
+		$this->assertContains('default', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+	}
 
-    protected function setUp(): void
-    {
-        parent::setUp();
 
-        $this->userSession = $this->createMock(IUserSession::class);
-        $this->user = $this->createMock(IUser::class);
-        $this->config = $this->createMock(IConfig::class);
-        $this->themingDefaults = $this->createMock(ThemingDefaults::class);
+    /**
+     * Test situation is
+     * - user logged in
+     * - user has a mix of existing and non-existing set, but none is a selectable theme
+     *   (default is then the main theme to use)
+     */
+	public function testObsoleteAndActualNoUserThemeSelected() {
+		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
+		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
+		$this->config->expects($this->any())->method('getUserValue')
+            ->with($this->equalTo('0815user'), $this->equalTo('nmctheme'),
+                    $this->equalTo('enabled-themes'), $this->equalTo('[]'))
+            ->willReturn('["darkforce","selectable1","teleneoweb","bluebay","static1"]');
 
-        $this->themingDefaults->expects($this->any())
-            ->method('getColorPrimary')
-            ->willReturn('#0082c9');
+		$enabledThemes = $this->themesService->getEnabledThemes();
+        $this->assertCount(5, $enabledThemes);
+        $this->assertContains('default', $enabledThemes);
+        $this->assertContains('selectable1', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+	}
 
-        $this->themingDefaults->expects($this->any())
-            ->method('getDefaultColorPrimary')
-            ->willReturn('#0082c9');
+    /**
+     * Test situation is
+     * - user logged in
+     * - user has a mix of existing and non-existing set
+     * - selection contains a main theme
+     */
+	public function testObsoleteAndActualUserThemeSelected() {
+		$this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);
+		$this->user->expects($this->any())->method('getUID')->willReturn('0815user');
+		$this->config->expects($this->any())->method('getUserValue')
+            ->with($this->equalTo('0815user'), $this->equalTo('nmctheme'),
+                    $this->equalTo('enabled-themes'), $this->equalTo('[]'))
+            ->willReturn('["selectable2","selectable1","teleneoweb","bluebay","static1"]');
 
-        $this->appManager = $this->createMock(IAppManager::class);
-        //$this->appManager->expects($this->once())
-        //    ->method('getAppWebPath')
-        //    ->willReturn('/strangeapps/nmctheme/');
-
-        // prpeare a complex theme setup
-        $app = new \OCP\AppFramework\App(Application::APP_ID);
-        $this->defaultTheme = $app->getContainer()->get(Magenta::class);
-        $selectable1 = $this->createMock(ITheme::class);
-        $selectable1->expects($this->any())->method('getId')->willReturn("selectable1");
-        $selectable1->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_FONT);
-        $selectable2 = $this->createMock(ITheme::class);
-        $selectable2->expects($this->any())->method('getId')->willReturn("selectable2");
-        $selectable2->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_THEME);
-        $this->selectableThemes = [ $app->getContainer()->get(MagentaDark::class),
-                                    $selectable1, $selectable2 ];
-
-        $static1 = $this->createMock(ITheme::class);
-        $static1->expects($this->any())->method('getId')->willReturn("static1");
-        $static1->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_FONT);
-        $static2 = $this->createMock(ITheme::class);
-        $static2->expects($this->any())->method('getId')->willReturn("static2");
-        $static2->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_THEME);                            
-        $this->staticThemes = [ $app->getContainer()->get(TeleNeoWebFont::class),
-                                $static1, $static2 ];
-
-        $this->themesService = new NMCThemesService(
-            $this->userSession,
-            $this->config,
-            $this->defaultTheme,
-            $this->selectableThemes,
-            $this->staticThemes,
-            $app->getContainer()->get(DefaultTheme::class),
-            $app->getContainer()->get(LightTheme::class),
-            $app->getContainer()->get(DarkTheme::class),
-            $app->getContainer()->get(HighContrastTheme::class),
-            $app->getContainer()->get(DarkHighContrastTheme::class),
-            $app->getContainer()->get(DyslexiaFont::class)
-        );
-    }
-
-    function testClassMapping() {
-        $themeClasses = $this->themesService->getThemes();
-        $this->assertCount(7,$themeClasses);
-        $this->assertArrayHasKey('magenta25', $themeClasses);
-        $this->assertArrayHasKey('magenta25dark', $themeClasses);
-        $this->assertArrayHasKey('selectable1', $themeClasses);
-        $this->assertArrayHasKey('selectable2', $themeClasses);
-        $this->assertArrayHasKey('teleneoweb', $themeClasses);
-        $this->assertArrayHasKey('static1', $themeClasses);
-        $this->assertArrayHasKey('static2', $themeClasses);
-    }
-
-    function testAnonymousDefault() {
-        $this->config->expects($this->never())->method('getUserValue');
-        $this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
-        $this->userSession->expects($this->once())->method('getUser')->willReturn(null);        
-    
-        $enabledThemes = $this->themesService->getEnabledThemes();
-    }
-
-    function testUnthemedUser() {
-        $this->config->expects($this->any())->method('getUserValue')->willReturn('[]');
-        $this->config->expects($this->once())->method('getSystemValueString')->willReturn('');
-        $this->userSession->expects($this->any())->method('getUser')->willReturn($this->user);        
-        $this->user->expects($this->any())->method('getUID')->willReturn('0815user');
-
-        $enabledThemes = $this->themesService->getEnabledThemes();
-    }
-
+		$enabledThemes = $this->themesService->getEnabledThemes();
+        $this->assertCount(5, $enabledThemes);
+        $this->assertContains('selectable1', $enabledThemes);
+        $this->assertContains('selectable2', $enabledThemes);
+		$this->assertContains('teleneoweb', $enabledThemes);
+		$this->assertContains('static1', $enabledThemes);
+		$this->assertContains('static2', $enabledThemes);
+	}
 
 }

--- a/tests/unit/Service/NMCThemesServiceTestCase.php
+++ b/tests/unit/Service/NMCThemesServiceTestCase.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\NMCTheme\Tests\Service;
+
+use OCA\NMCTheme\AppInfo\Application;
+use OCA\NMCTheme\Service\NMCThemesService;
+use OCA\NMCTheme\Themes\Magenta;
+use OCA\NMCTheme\Themes\MagentaDark;
+
+use OCA\NMCTheme\Themes\TeleNeoWebFont;
+
+use OCA\Theming\ITheme;
+use OCA\Theming\Service\ThemesService;
+use OCA\Theming\Themes\DarkHighContrastTheme;
+use OCA\Theming\Themes\DarkTheme;
+use OCA\Theming\Themes\DefaultTheme;
+
+use OCA\Theming\Themes\DyslexiaFont;
+use OCA\Theming\Themes\HighContrastTheme;
+use OCA\Theming\Themes\LightTheme;
+
+use OCA\Theming\ThemingDefaults;
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base test fixture for ThemesService unittests.
+ *
+ * Hint: Make sure that your bootstrap.php contains a PSR4
+ * registration for the unittest root dir
+ * \OC::$composerAutoloader->addPsr4('OCA\\NMCTheme\\Tests\\', dirname(__FILE__) . '/unit/', true);
+ *
+ */
+
+class NMCThemesServiceTestCase extends TestCase {
+	/** @var ThemesService */
+	protected $themesService;
+
+	/** @var IUserSession */
+	protected $userSession;
+	/** @var IConfig */
+	protected $config;
+	/** @var ThemingDefaults */
+	protected $themingDefaults;
+	/** @var AppManager */
+	protected $appManager;
+
+	/** @var ITheme */
+	protected $defaultTheme;
+	/** @var ITheme[] */
+	protected $selectableThemes;
+	/** @var ITheme[] */
+	protected $staticThemes;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
+
+		$this->themingDefaults->expects($this->any())
+			->method('getColorPrimary')
+			->willReturn('#0082c9');
+
+		$this->themingDefaults->expects($this->any())
+			->method('getDefaultColorPrimary')
+			->willReturn('#0082c9');
+
+		$this->appManager = $this->createMock(IAppManager::class);
+		//$this->appManager->expects($this->once())
+		//    ->method('getAppWebPath')
+		//    ->willReturn('/strangeapps/nmctheme/');
+
+		// prpeare a complex theme setup
+		$app = new \OCP\AppFramework\App(Application::APP_ID);
+		$this->defaultTheme = $app->getContainer()->get(Magenta::class);
+		$selectable1 = $this->createMock(ITheme::class);
+		$selectable1->expects($this->any())->method('getId')->willReturn("selectable1");
+		$selectable1->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_FONT);
+		$selectable2 = $this->createMock(ITheme::class);
+		$selectable2->expects($this->any())->method('getId')->willReturn("selectable2");
+		$selectable2->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_THEME);
+		$this->selectableThemes = [ $app->getContainer()->get(MagentaDark::class),
+			$selectable1, $selectable2 ];
+
+		$static1 = $this->createMock(ITheme::class);
+		$static1->expects($this->any())->method('getId')->willReturn("static1");
+		$static1->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_FONT);
+		$static2 = $this->createMock(ITheme::class);
+		$static2->expects($this->any())->method('getId')->willReturn("static2");
+		$static2->expects($this->any())->method('getType')->willReturn(ITheme::TYPE_THEME);
+		$this->staticThemes = [ $app->getContainer()->get(TeleNeoWebFont::class),
+			$static1, $static2 ];
+
+		$this->themesService = new NMCThemesService(
+			$this->userSession,
+			$this->config,
+			$this->defaultTheme,
+			$this->selectableThemes,
+			$this->staticThemes,
+			$app->getContainer()->get(DefaultTheme::class),
+			$app->getContainer()->get(LightTheme::class),
+			$app->getContainer()->get(DarkTheme::class),
+			$app->getContainer()->get(HighContrastTheme::class),
+			$app->getContainer()->get(DarkHighContrastTheme::class),
+			$app->getContainer()->get(DyslexiaFont::class)
+		);
+	}
+}


### PR DESCRIPTION
Redesign nmctheme to register own themes on boot without the need of an upstream server change.

The idea is to use Dependency Injection to override the ThemesService injected into
the system.

The new NMCThemesService handles the following cases:

- you can define the list of themes on boot in service registration
- you can set default theme to use (as a kind of alias)
- you can define a set of "static" themes to always include
- if no user theme is set, the default (either configured or from registration) is used