### PR TITLE
Poor mans footer component for theming

### DIFF
--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -28,23 +28,33 @@ footer[role="contentinfo"] {
     z-index: 998;
     border-radius: var(--border-radius);
 
-
-    .footer-content {
     // TODO: fixed height?, as we may have to set padding etc.
     // height: auto;
     border-left: var(--telekom-spacing-composition-space-08);
     border-right: var(--telekom-spacing-composition-space-08);
     border-bottom: var(--telekom-spacing-composition-space-08);
+    border-top: var(--telekom-spacing-composition-space-01) solid var(--telekom-color-ui-faint);
     padding: var(--telekom-spacing-composition-space-08);
 
-    //border-radius: 0px;
+    .footer-content {
+
+
+        //border-radius: 0px;
         display: grid;
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
-        grid-template-areas: 'notice ........ navigation';
+        grid-template-areas: 'notice ....... navigation';
         grid-auto-rows: max-content;
-        width: 100%;
+        row-gap: 0px;
 
-        ul {
+        // no linebreaks for labels
+        white-space: nowrap;
+
+        #notice {
+            grid-area: notice;
+        }
+
+        #navigation {
+            grid-area: navigation;
             list-style-type: none;
             padding: 0;
             margin: 0;
@@ -84,14 +94,13 @@ footer[role="contentinfo"] {
     }
 }
 
-/*
-@media (max-width: var(--nmcbreakpoint-mobile)) {
+@media (max-width: var(--nmc-breakpoint-mobile)) {
     .footer-content {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
         grid-template-areas:
-            'branding ....... .......'
-            'copyright navigation navigation';
+            'notice ....... .......'
+            'navigation navigation navigation';
 
         #notice {
             justify-content: flex-start;
@@ -102,4 +111,3 @@ footer[role="contentinfo"] {
         }
     }
 }
-*/

--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -13,17 +13,18 @@ footer {
     --footnav-items-bottom-margin: var(--telekom-spacing-composition-space-08);
     --radius: var(--telekom-radius-small);
     --border-radius: 0px;
-    --footer-font: var(--telekom-text-style-caption-bold)
+    --footer-font: var(--telekom-text-style-caption-bold);
 }
 
 #body-login footer[role="contentinfo"],
 // need to override NC guest.scss
 footer[role="contentinfo"] {
+    background-color: var(--color-main-background);
     font: var(--footer-font);
     position: fixed;
     left: 0;
     bottom: 0;
-    width: 100%;
+    right: 0;
     max-height: var(--telekom-spacing-baseline-space-3);
     z-index: 998;
     border-radius: var(--border-radius);
@@ -36,40 +37,27 @@ footer[role="contentinfo"] {
     border-top: var(--telekom-spacing-composition-space-01) solid var(--telekom-color-ui-faint);
     padding: var(--telekom-spacing-composition-space-08);
 
-    .footer-content {
-
-
-        //border-radius: 0px;
-        display: grid;
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
-        grid-template-areas: 'notice ....... navigation';
-        grid-auto-rows: max-content;
-        row-gap: 0px;
-
-        // no linebreaks for labels
-        white-space: nowrap;
+    .footer-content {        
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--telekom-spacing-composition-space-06);
 
         #notice {
-            grid-area: notice;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
         }
 
         #navigation {
-            grid-area: navigation;
-            list-style-type: none;
-            padding: 0;
-            margin: 0;
             display: flex;
-            list-style: none;
+            justify-content: space-between;
             gap: var(--telekom-spacing-composition-space-05);
-        }
-
-        li {
-            float: aleft;
+            flex-wrap: wrap;
         }
 
         li a {
             font: var(--footer-font); // override NC guest.scss
-            align-items: center;
             padding: var(--spacing-navigation-standard);
             margin: calc(-1 * var(--spacing-navigation-standard)) 0;
         }
@@ -95,19 +83,7 @@ footer[role="contentinfo"] {
 }
 
 @media (max-width: var(--nmc-breakpoint-mobile)) {
-    .footer-content {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-        grid-template-areas:
-            'notice ....... .......'
-            'navigation navigation navigation';
-
-        #notice {
-            justify-content: flex-start;
-        }
-
-        #navigation {
-            margin-bottom: var(--telekom-spacing-composition-space-05)
-        }
+    #navigation {
+        flex-direction: column;
     }
 }

--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -1,0 +1,105 @@
+/**
+ * The MagentaCLOUD style rules package for Nextcloud
+ *
+ * @copyright Copyright (c) 2023 T-Systems International
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ * @author Aleksei Efremov <Aleksei.Efremov@telekom.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Note: Take care of Telekom branding restrictions!
+ */
+
+footer {
+    --footnav-items-bottom-margin: var(--telekom-spacing-composition-space-08);
+    --radius: var(--telekom-radius-small);
+    --border-radius: 0px;
+    --footer-font: var(--telekom-text-style-caption-bold)
+}
+
+#body-login footer[role="contentinfo"],
+// need to override NC guest.scss
+footer[role="contentinfo"] {
+    font: var(--footer-font);
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    max-height: var(--telekom-spacing-baseline-space-3);
+    z-index: 998;
+    border-radius: var(--border-radius);
+
+
+    .footer-content {
+    // TODO: fixed height?, as we may have to set padding etc.
+    // height: auto;
+    border-left: var(--telekom-spacing-composition-space-08);
+    border-right: var(--telekom-spacing-composition-space-08);
+    border-bottom: var(--telekom-spacing-composition-space-08);
+    padding: var(--telekom-spacing-composition-space-08);
+
+    //border-radius: 0px;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+        grid-template-areas: 'notice ........ navigation';
+        grid-auto-rows: max-content;
+        width: 100%;
+
+        ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            list-style: none;
+            gap: var(--telekom-spacing-composition-space-05);
+        }
+
+        li {
+            float: aleft;
+        }
+
+        li a {
+            font: var(--footer-font); // override NC guest.scss
+            align-items: center;
+            padding: var(--spacing-navigation-standard);
+            margin: calc(-1 * var(--spacing-navigation-standard)) 0;
+        }
+
+        li a:hover {
+            color: var(--telekom-color-text-and-icon-primary-hovered);
+            text-decoration: none;
+        }
+
+        li a:active:focus {
+            color: var(--telekom-color-text-and-icon-primary-pressed);
+            box-shadow: none;
+            text-decoration: none;
+        }
+
+        li a:focus {
+            outline: none;
+            box-shadow: 0 0 0 var(--telekom-spacing-composition-space-02) var(--telekom-color-functional-focus-standard);
+            border-radius: var(--radius);
+            text-decoration: none;
+        }
+    }
+}
+
+/*
+@media (max-width: var(--nmcbreakpoint-mobile)) {
+    .footer-content {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+        grid-template-areas:
+            'branding ....... .......'
+            'copyright navigation navigation';
+
+        #notice {
+            justify-content: flex-start;
+        }
+
+        #navigation {
+            margin-bottom: var(--telekom-spacing-composition-space-05)
+        }
+    }
+}
+*/

--- a/css/layouts/header.scss
+++ b/css/layouts/header.scss
@@ -1,3 +1,15 @@
+/**
+ * The MagentaCLOUD style rules package for Nextcloud
+ *
+ * @copyright Copyright (c) 2023 T-Systems International
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ * @author Aleksei Efremov <Aleksei.Efremov@telekom.com>
+ * @author Mauro Mura <Mauro-Efisio.Mura@t-systems.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Note: Take care of Telekom branding restrictions!
+ */
+ 
 $breakpoint-mobile: 1024px;
 
 header {

--- a/css/layouts/login.scss
+++ b/css/layouts/login.scss
@@ -30,7 +30,6 @@
         background-position: top center;
         background-repeat: no-repeat;
         background-clip: border-box;
-        z-index: 200;
 
         .v-align header #header .logo {
             background-image: unset;
@@ -39,6 +38,10 @@
         // default logo is disabled
         // and takes no space
     }
+}
+
+#body-login footer[role="contentinfo"] {
+    opacity: var(--telekom-opacity-semi-transparent);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/css/layouts/login.scss
+++ b/css/layouts/login.scss
@@ -23,6 +23,7 @@
         border-top: 0px;
         margin-top: 0px;
 
+
         // the bubble text is always on top center,
         // but clipped if window gets too small
         background-image: url('../img/telekom/mcbubble.svg');
@@ -30,9 +31,14 @@
         background-position: top center;
         background-repeat: no-repeat;
         background-clip: border-box;
+        z-index: 200;
 
-        .v-align header #header .logo {
-            background-image: unset;
+        .v-align {
+            top: 0;
+
+            header #header .logo {
+                background-image: unset;
+            }
         }
 
         // default logo is disabled
@@ -41,7 +47,7 @@
 }
 
 #body-login footer[role="contentinfo"] {
-    opacity: var(--telekom-opacity-semi-transparent);
+    opacity: var(--telekom-opacity-translucent);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/css/layouts/status.scss
+++ b/css/layouts/status.scss
@@ -32,10 +32,15 @@
     }
 }
 
-@media (prefers-color-scheme: dark) {
+#error #body-status footer[role="contentinfo"],
+#body-status footer[role="contentinfo"] {
+    opacity: var(--telekom-opacity-semi-transparent);
+    color: var(--telekom-color-text-and-icon-white-standard);
+}
 
+@media (prefers-color-scheme: dark) {
     #error,
-    #body-login {
+    #body-status {
         background-image: linear-gradient(rgba(0, 0, 0, 0.5),
                 rgba(0, 0, 0, 0.5)),
             url('../img/telekom/tectopview23.jpg');

--- a/css/layouts/user.scss
+++ b/css/layouts/user.scss
@@ -1,0 +1,14 @@
+/**
+ * The MagentaCLOUD user general layout (w/o header, footer)
+ *
+ * @copyright Copyright (c) 2023 T-Systems International
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Note: Take care of Telekom branding restrictions!
+ */
+#body-user #content {
+
+    // FIXME  find a better way to get some space for the footer
+    // in user (and public layouts?) only
+    // Remember that you have two lines on mobile view
+    padding-bottom: calc(2*var(--telekom-spacing-composition-space-08) + var(--telekom-spacing-composition-space-03) + var(--telekom-typography-font-size-caption));
+}

--- a/css/nmcdefault.scss
+++ b/css/nmcdefault.scss
@@ -95,4 +95,6 @@
   --image-background-default: none;
   --image-logoheader-custom: var(--image-logoheader);
   --color-background-plain: var(--telekom-color-background-canvas);
+
+  --nmc-breakpoint-mobile: 1024px;
 }

--- a/css/nmcstyle.scss
+++ b/css/nmcstyle.scss
@@ -21,6 +21,7 @@
 @import 'layouts/header.scss';
 @import 'layouts/footer.scss';
 @import 'layouts/login.scss'; 
+@import 'layouts/user.scss';
 @import 'layouts/public.scss';
 @import 'layouts/status.scss'; 
 

--- a/css/nmcstyle.scss
+++ b/css/nmcstyle.scss
@@ -19,6 +19,7 @@
 
 /* layouts and layout parts*/
 @import 'layouts/header.scss';
+@import 'layouts/footer.scss';
 @import 'layouts/login.scss'; 
 @import 'layouts/public.scss';
 @import 'layouts/status.scss'; 

--- a/js/nmcfooter.js
+++ b/js/nmcfooter.js
@@ -1,11 +1,4 @@
-var footerElement = document.querySelector('body footer');
-if ( footerElement === null ) {
-    // add footer tag
-    footerElement = document.createElement('footer');
-    document.body.appendChild(footerElement);
-} 
-
-footerElement.innerHTML=`
+const footerContent =`
 <div class="footer-content">
     <div id="notice">
         (C) Telekom Deutschland GmbH
@@ -18,12 +11,20 @@ footerElement.innerHTML=`
         <li><a href="https://cloud.telekom-dienste.de/hilfe" target="_blank" rel="noreferrer noopener">Hilfe und FAQ</a></li>
     </ul>
 </div>
-`; 
-footerElement.setAttribute('role', 'contentinfo');
-footerElement.setAttribute('id', 'telekom-minimal-footer');
+`;
+const footerRole = 'contentinfo';
+const footerId = 'telekom-minimal-footer';
 
+var footerElement = document.querySelector('body footer');
 if ( footerElement === null ) {
     // add footer tag
     footerElement = document.createElement('footer');
+    footerElement.innerHTML=footerContent; 
+    footerElement.setAttribute('role', footerRole);
+    footerElement.setAttribute('id', footerId);
     document.body.appendChild(footerElement);
-} 
+} else {
+    footerElement.innerHTML=footerContent; 
+    footerElement.setAttribute('role', footerRole);
+    footerElement.setAttribute('id', footerId);
+}

--- a/js/nmcfooter.js
+++ b/js/nmcfooter.js
@@ -2,7 +2,7 @@ class TeleBrandFooter extends HTMLElement {
     connectedCallback() {
         this.innerHTML = `
         <footer id="telekom-footer" role="contentinfo">
-            <div class="telekom-footer-content">
+            <div class="telekom-footer-minimal">
                 <div id="notice">
                     (C) Telekom Deutschland GmbH
                 </div>

--- a/js/nmcfooter.js
+++ b/js/nmcfooter.js
@@ -1,0 +1,36 @@
+class TeleBrandFooter extends HTMLElement {
+    connectedCallback() {
+        this.innerHTML = `
+        <footer id="telekom-footer" role="contentinfo">
+            <div class="telekom-footer-content">
+                <div id="notice">
+                    Copyright Telekom Deutschland GmbH
+                </div>
+                <ul id="navigation">
+                    <li><a href="https://static.magentacloud.de/licences/webui.htm" target="_blank">Open Source Lizenzen</a>
+                    <li><a href="http://www.telekom.de/impressum" target="_blank">Impressum</a></li>
+                    <li><a href="https://static.magentacloud.de/Datenschutz" target="_blank">Datenschutz</a>
+                    </li>
+                    <li><a href="https://cloud.telekom-dienste.de/hilfe" target="_blank">Hilfe & FAQ</a></li>
+                </ul>
+            </div>
+        </footer>
+        `;
+    }
+}
+
+var footerElement = document.querySelector('body footer');
+if ( footerElement === null ) {
+    // add footer tag
+    document.body.appendChild(new TeleBrandFooter());
+} else {
+    //replace footer tag
+    document.body.replaceChild(new TeleBrandFooter(), footerElement);
+}
+
+
+
+
+
+
+

--- a/js/nmcfooter.js
+++ b/js/nmcfooter.js
@@ -4,20 +4,22 @@ class TeleBrandFooter extends HTMLElement {
         <footer id="telekom-footer" role="contentinfo">
             <div class="telekom-footer-content">
                 <div id="notice">
-                    Copyright Telekom Deutschland GmbH
+                    (C) Telekom Deutschland GmbH
                 </div>
                 <ul id="navigation">
-                    <li><a href="https://static.magentacloud.de/licences/webui.htm" target="_blank">Open Source Lizenzen</a>
-                    <li><a href="http://www.telekom.de/impressum" target="_blank">Impressum</a></li>
-                    <li><a href="https://static.magentacloud.de/Datenschutz" target="_blank">Datenschutz</a>
+                    <li><a href="https://static.magentacloud.de/licences/webui.htm" target="_blank" rel="noreferrer noopener">Open Source Lizenzen</a>
+                    <li><a href="http://www.telekom.de/impressum" target="_blank" rel="noreferrer noopener">Impressum</a></li>
+                    <li><a href="https://static.magentacloud.de/Datenschutz" target="_blank" rel="noreferrer noopener">Datenschutz</a>
                     </li>
-                    <li><a href="https://cloud.telekom-dienste.de/hilfe" target="_blank">Hilfe & FAQ</a></li>
+                    <li><a href="https://cloud.telekom-dienste.de/hilfe" target="_blank" rel="noreferrer noopener">Hilfe und FAQ</a></li>
                 </ul>
             </div>
         </footer>
         `;
     }
 }
+
+window.customElements.define('telekom-footer-element', TeleBrandFooter);
 
 var footerElement = document.querySelector('body footer');
 if ( footerElement === null ) {

--- a/js/nmcfooter.js
+++ b/js/nmcfooter.js
@@ -19,12 +19,12 @@ var footerElement = document.querySelector('body footer');
 if ( footerElement === null ) {
     // add footer tag
     footerElement = document.createElement('footer');
-    footerElement.innerHTML=footerContent; 
+    footerElement.innerHTML = footerContent; 
     footerElement.setAttribute('role', footerRole);
     footerElement.setAttribute('id', footerId);
     document.body.appendChild(footerElement);
 } else {
-    footerElement.innerHTML=footerContent; 
+    footerElement.innerHTML = footerContent; 
     footerElement.setAttribute('role', footerRole);
     footerElement.setAttribute('id', footerId);
 }

--- a/js/nmcfooter.js
+++ b/js/nmcfooter.js
@@ -1,38 +1,29 @@
-class TeleBrandFooter extends HTMLElement {
-    connectedCallback() {
-        this.innerHTML = `
-        <footer id="telekom-footer" role="contentinfo">
-            <div class="telekom-footer-minimal">
-                <div id="notice">
-                    (C) Telekom Deutschland GmbH
-                </div>
-                <ul id="navigation">
-                    <li><a href="https://static.magentacloud.de/licences/webui.htm" target="_blank" rel="noreferrer noopener">Open Source Lizenzen</a>
-                    <li><a href="http://www.telekom.de/impressum" target="_blank" rel="noreferrer noopener">Impressum</a></li>
-                    <li><a href="https://static.magentacloud.de/Datenschutz" target="_blank" rel="noreferrer noopener">Datenschutz</a>
-                    </li>
-                    <li><a href="https://cloud.telekom-dienste.de/hilfe" target="_blank" rel="noreferrer noopener">Hilfe und FAQ</a></li>
-                </ul>
-            </div>
-        </footer>
-        `;
-    }
-}
-
-window.customElements.define('telekom-footer-element', TeleBrandFooter);
-
 var footerElement = document.querySelector('body footer');
 if ( footerElement === null ) {
     // add footer tag
-    document.body.appendChild(new TeleBrandFooter());
-} else {
-    //replace footer tag
-    document.body.replaceChild(new TeleBrandFooter(), footerElement);
-}
+    footerElement = document.createElement('footer');
+    document.body.appendChild(footerElement);
+} 
 
+footerElement.innerHTML=`
+<div class="footer-content">
+    <div id="notice">
+        (C) Telekom Deutschland GmbH
+    </div>
+    <ul id="navigation">
+        <li><a href="https://static.magentacloud.de/licences/webui.htm" target="_blank" rel="noreferrer noopener">Open Source Lizenzen</a>
+        <li><a href="http://www.telekom.de/impressum" target="_blank" rel="noreferrer noopener">Impressum</a></li>
+        <li><a href="https://static.magentacloud.de/Datenschutz" target="_blank" rel="noreferrer noopener">Datenschutz</a>
+        </li>
+        <li><a href="https://cloud.telekom-dienste.de/hilfe" target="_blank" rel="noreferrer noopener">Hilfe und FAQ</a></li>
+    </ul>
+</div>
+`; 
+footerElement.setAttribute('role', 'contentinfo');
+footerElement.setAttribute('id', 'telekom-minimal-footer');
 
-
-
-
-
-
+if ( footerElement === null ) {
+    // add footer tag
+    footerElement = document.createElement('footer');
+    document.body.appendChild(footerElement);
+} 

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -39,8 +39,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			$response->setParams($tmplparams);
 		}
 
-		// you can add extra styles depending on situation
-		//     \OCP\Util::addStyle("nmctheme", "some_extra_xxx");
-		// }
+		// you can add additional styles, links and scripts before rendering
+		\OCP\Util::addScript('nmctheme', 'nmcfooter', 'theming');
 	}
 }


### PR DESCRIPTION
Nextcloud does not support a footer components consistently, esp. not on user and public layout.
The PR adds Javascript that replaces the inconsistent <footer> elements with a uniform header structure
for all layouts.

It contains also the core adaptions needed in stylesheet to place content properly.

It does not support language translation yet.
The links are not taken from <link> metadata in header yet. 