### PR TITLE
Generate sass on build, but no webpacks yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "stylelint": "^15.10.3"
     },
     "scripts": {
+        "build": "npm run sass && npm run sass:icons",
         "lint": "eslint js",
         "lint:fix": "eslint js --fix",
         "stylelint": "stylelint css",


### PR DESCRIPTION
The packaging process is missing the `build` (and the `postbuild`) command in `package.json`.

So far, only sass and icon generation is needed.