### PR TITLE
Fix: Show status also for server errors

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -32,7 +32,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 	public function handle(Event $event): void {
 		$response = $event->getResponse();
 
-		if (($response->getStatus() >= 400) && ($response->getStatus() < 500)) {
+		if (($response->getStatus() >= 400) && ($response->getStatus() < 600)) {
 			// render client error states with own layout => own #body-status id
 			$tmplparams = $response->getParams();
 			$tmplparams['bodyid'] = "body-status";


### PR DESCRIPTION
Show status page also for server errors with status code >=500
These are in the range up to code<600.
