### PR TITLE
E2e encryption translations

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -16,17 +16,18 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Erwartete Dateigröße von %1$s, aber %2$s gelesen (vom MagentaCLOUD-Client) und geschrieben (in den MagentaCLOUD-Speicher). Dies kann entweder ein Netzwerkproblem auf der sendenden Seite oder ein Problem beim Schreiben in den Speicher auf der Serverseite sein."
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "end_to_end_encryption": { "translations": {
-    "End to end encryption is currently enabled." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
-    "Reset encryption" : "Verschlüsselung zurücksetzen",
-    "Please read carefully before resetting your end-to-end encryption keys" : "Bitte vor der Zurücksetzung der Ende-zu-Ende Verschlüsselung aufmerksam lesen",
-    "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted." : "Sobald die Verschlüsselung zurückgesetzt wird, werden sämtliche verschlüsselten Dateien/Ordner gelöscht.",
-    "Before you reset your encryption, check your apps and desktop clients to make sure you really can not access your keys anywhere." : "Sofern die Passphrase vergessen wurde, kann diese in den Apps oder Desktop Clients der MagentaCLOUD ausgelesen werden. Eine Zurücksetzung ist nicht zwingend notwendig.",
-    "If you want to reset the encryption even though your keys are still available in the apps or desktop clients, then delete the keys locally on the other devices. Alternatively, you can reset the apps or reconnect the desktop clients to your account." : "Sollten Sie die Verschlüsselung zurücksetzen wollen, obwohl ihre Passphrase in den Apps oder Desktop Clients der MagentaCLOUD noch vorhanden sind, entfernen Sie die Passphrase anschließend auch lokal auf den anderen Endgeräten. Alternativ können Sie die Apps auch zurücksetzen und sich erneut mit ihrer MagentaCLOUD verbinden.",
-    "Confirm and reset" : "Bestätigen und zurücksetzen",
-    "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted." : "Das ist die letzte Warnung: Möchten Sie wirklich die Verschlüsselung zurücksetzen? Verschlüsselte Daten gehen dabei verloren und werden gelöscht.",
+    "Reset End-to-End encryption" : "Verschlüsselung zurücksetzen",
+    "Please read carefully before resetting your end-to-end encryption keys" : "Bitte vor dem Zurücksetzen Ihrer Schlüssel für die Ende-zu-Ende-Verschlüsselung aufmerksam lesen!",
+    "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Sobald die Verschlüsselung zurückgesetzt wird, werden sämtliche verschlüsselten Dateien/Ordner gelöscht!",
+    "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "Sofern die Passphrase vergessen wurde, kann diese in den Apps oder Desktop Clients der MagentaCLOUD ausgelesen werden. Eine Zurücksetzung ist nicht zwingend notwendig.",
+    "Check on all connected devices if you can retrieve your mnemonic." : "Sollten Sie trotzdem die Verschlüsselung zurücksetzen wollen, obwohl ihre Passphrase in den Apps oder Desktop Clients der MagentaCLOUD noch vorhanden sind, entfernen Sie die Passphrase anschließend auch lokal auf den anderen Endgeräten.",
+    "Any still connected device might cause problems after deleting the keys, so it is better to disconnect and reconnect the devices again." : "Nach dem Zurücksetzen können Sie auch alternativ auch die App-Installation zurücksetzen und sich erneut mit ihrer MagentaCLOUD verbinden.",
+    "Confirm and reset End-to-End encryption" : "Bestätigen und zurücksetzen",
+    "This is the final warning: Do you really want to reset your keys?" : "Das ist die letzte Warnung: Möchten Sie wirklich die Verschlüsselung zurücksetzen? Verschlüsselte Daten gehen dabei verloren und werden gelöscht.",
+    "End-to-End encryption is currently enabled and correctly setup." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
     "Cancel" : "Abbrechen",
     "Confirm" : "Bestätigen",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den Apps oder Desktop Clients einrichten."
+    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten."
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {
     "Crop image previews": "Vorschaubilder  beschneiden",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -27,7 +27,8 @@
     "End-to-End encryption is currently enabled and correctly setup." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
     "Cancel" : "Abbrechen",
     "Confirm" : "Bestätigen",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten."
+    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
+    "You are not allowed to lock the root": "Das Sperren deines gesamten Verzeichnisbaumes durch E2E-Encryption wurde verhindert!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {
     "Crop image previews": "Vorschaubilder  beschneiden",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -16,17 +16,18 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Erwartete Dateigröße von %1$s, aber %2$s gelesen (vom MagentaCLOUD-Client) und geschrieben (in den MagentaCLOUD-Speicher). Dies kann entweder ein Netzwerkproblem auf der sendenden Seite oder ein Problem beim Schreiben in den Speicher auf der Serverseite sein."
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "end_to_end_encryption": { "translations": {
-    "End to end encryption is currently enabled." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
-    "Reset encryption" : "Verschlüsselung zurücksetzen",
-    "Please read carefully before resetting your end-to-end encryption keys" : "Bitte vor der Zurücksetzung der Ende-zu-Ende Verschlüsselung aufmerksam lesen",
-    "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted." : "Sobald die Verschlüsselung zurückgesetzt wird, werden sämtliche verschlüsselten Dateien/Ordner gelöscht.",
-    "Before you reset your encryption, check your apps and desktop clients to make sure you really can not access your keys anywhere." : "Sofern die Passphrase vergessen wurde, kann diese in den Apps oder Desktop Clients der MagentaCLOUD ausgelesen werden. Eine Zurücksetzung ist nicht zwingend notwendig.",
-    "If you want to reset the encryption even though your keys are still available in the apps or desktop clients, then delete the keys locally on the other devices. Alternatively, you can reset the apps or reconnect the desktop clients to your account." : "Sollten Sie die Verschlüsselung zurücksetzen wollen, obwohl ihre Passphrase in den Apps oder Desktop Clients der MagentaCLOUD noch vorhanden sind, entfernen Sie die Passphrase anschließend auch lokal auf den anderen Endgeräten. Alternativ können Sie die Apps auch zurücksetzen und sich erneut mit ihrer MagentaCLOUD verbinden.",
-    "Confirm and reset" : "Bestätigen und zurücksetzen",
-    "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted." : "Das ist die letzte Warnung: Möchten Sie wirklich die Verschlüsselung zurücksetzen? Verschlüsselte Daten gehen dabei verloren und werden gelöscht.",
+    "Reset End-to-End encryption" : "Verschlüsselung zurücksetzen",
+    "Please read carefully before resetting your end-to-end encryption keys" : "Bitte vor dem Zurücksetzen Ihrer Schlüssel für die Ende-zu-Ende-Verschlüsselung aufmerksam lesen!",
+    "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Sobald die Verschlüsselung zurückgesetzt wird, werden sämtliche verschlüsselten Dateien/Ordner gelöscht!",
+    "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "Sofern die Passphrase vergessen wurde, kann diese in den Apps oder Desktop Clients der MagentaCLOUD ausgelesen werden. Eine Zurücksetzung ist nicht zwingend notwendig.",
+    "Check on all connected devices if you can retrieve your mnemonic." : "Sollten Sie trotzdem die Verschlüsselung zurücksetzen wollen, obwohl ihre Passphrase in den Apps oder Desktop Clients der MagentaCLOUD noch vorhanden sind, entfernen Sie die Passphrase anschließend auch lokal auf den anderen Endgeräten.",
+    "Any still connected device might cause problems after deleting the keys, so it is better to disconnect and reconnect the devices again." : "Nach dem Zurücksetzen können Sie auch alternativ auch die App-Installation zurücksetzen und sich erneut mit ihrer MagentaCLOUD verbinden.",
+    "Confirm and reset End-to-End encryption" : "Bestätigen und zurücksetzen",
+    "This is the final warning: Do you really want to reset your keys?" : "Das ist die letzte Warnung: Möchten Sie wirklich die Verschlüsselung zurücksetzen? Verschlüsselte Daten gehen dabei verloren und werden gelöscht.",
+    "End-to-End encryption is currently enabled and correctly setup." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
     "Cancel" : "Abbrechen",
     "Confirm" : "Bestätigen",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den Apps oder Desktop Clients einrichten."
+    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten."
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {
     "Crop image previews": "Vorschaubilder  beschneiden",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -27,7 +27,8 @@
     "End-to-End encryption is currently enabled and correctly setup." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
     "Cancel" : "Abbrechen",
     "Confirm" : "Bestätigen",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten."
+    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
+    "You are not allowed to lock the root": "Das Sperren deines gesamten Verzeichnisbaumes durch E2E-Encryption wurde verhindert!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {
     "Crop image previews": "Vorschaubilder  beschneiden",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -27,7 +27,8 @@
     "End-to-End encryption is currently enabled and correctly setup." : "End to end encryption is currently enabled.",
     "Cancel" : "Cancel",
     "Confirm" : "Confirm",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients."
+    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
+    "You are not allowed to lock the root": "The lock of your complete file tree by end2end encryption was prohibited by the system!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {
     "Crop image previews": "Crop image previews",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -16,14 +16,15 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Expected filesize of %1$s but read (from MagentaCLOUD client) and wrote (to MagentaCLOUD storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side."
     },"pluralForm" :"nplurals=2; plural=(n != 1);" },
   "end_to_end_encryption": { "translations": {
-    "End to end encryption is currently enabled." : "End to end encryption is currently enabled.",
-    "Reset encryption" : "Reset encryption",
-    "Please read carefully before resetting your end-to-end encryption keys" : "Please read carefully before resetting your end-​to-​end encryption keys",
-    "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted." : "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted.",
-    "Before you reset your encryption, check your apps and desktop clients to make sure you really can not access your keys anywhere." : "Before you reset your encryption, check your apps and desktop clients to make sure you really can not access your keys anywhere.",
-    "If you want to reset the encryption even though your keys are still available in the apps or desktop clients, then delete the keys locally on the other devices. Alternatively, you can reset the apps or reconnect the desktop clients to your account." : "If you want to reset the encryption even though your keys are still available in the apps or desktop clients, then delete the keys locally on the other devices. Alternatively, you can reset the apps or reconnect the desktop clients to your account.",
-    "Confirm and reset" : "Confirm and reset",
-    "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted." : "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted.",
+    "Reset End-to-End encryption" : "Reset encryption",
+    "Please read carefully before resetting your end-to-end encryption keys" : "Please read carefully before resetting your end-to-end encryption keys!",
+    "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted.",
+    "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "If you just forgot your passphrase, you can retrieve it in the MagentaCLOUD apps or desktop client. Key reset is not mandatory.",
+    "Check on all connected devices if you can retrieve your mnemonic." : "If you still want to reset the encryption even though your keys are still available in the apps or desktop clients, then remember to delete the keys also locally on the other devices.",
+    "Any still connected device might cause problems after deleting the keys, so it is better to disconnect and reconnect the devices again." : "Alternatively, after key reset, you can also set the apps to initial state and reconnect to your MagentaCLOUD account.",
+    "Confirm and reset End-to-End encryption" : "Confirm and reset",
+    "This is the final warning: Do you really want to reset your keys?" : "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted.",
+    "End-to-End encryption is currently enabled and correctly setup." : "End to end encryption is currently enabled.",
     "Cancel" : "Cancel",
     "Confirm" : "Confirm",
     "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients."

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -27,7 +27,8 @@
     "End-to-End encryption is currently enabled and correctly setup." : "End to end encryption is currently enabled.",
     "Cancel" : "Cancel",
     "Confirm" : "Confirm",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients."
+    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
+    "You are not allowed to lock the root": "The lock of your complete file tree by end2end encryption was prohibited by the system!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {
     "Crop image previews": "Crop image previews",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -16,14 +16,15 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Expected filesize of %1$s but read (from MagentaCLOUD client) and wrote (to MagentaCLOUD storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side."
     },"pluralForm" :"nplurals=2; plural=(n != 1);" },
   "end_to_end_encryption": { "translations": {
-    "End to end encryption is currently enabled." : "End to end encryption is currently enabled.",
-    "Reset encryption" : "Reset encryption",
-    "Please read carefully before resetting your end-to-end encryption keys" : "Please read carefully before resetting your end-​to-​end encryption keys",
-    "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted." : "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted.",
-    "Before you reset your encryption, check your apps and desktop clients to make sure you really can not access your keys anywhere." : "Before you reset your encryption, check your apps and desktop clients to make sure you really can not access your keys anywhere.",
-    "If you want to reset the encryption even though your keys are still available in the apps or desktop clients, then delete the keys locally on the other devices. Alternatively, you can reset the apps or reconnect the desktop clients to your account." : "If you want to reset the encryption even though your keys are still available in the apps or desktop clients, then delete the keys locally on the other devices. Alternatively, you can reset the apps or reconnect the desktop clients to your account.",
-    "Confirm and reset" : "Confirm and reset",
-    "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted." : "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted.",
+    "Reset End-to-End encryption" : "Reset encryption",
+    "Please read carefully before resetting your end-to-end encryption keys" : "Please read carefully before resetting your end-to-end encryption keys!",
+    "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted.",
+    "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "If you just forgot your passphrase, you can retrieve it in the MagentaCLOUD apps or desktop client. Key reset is not mandatory.",
+    "Check on all connected devices if you can retrieve your mnemonic." : "If you still want to reset the encryption even though your keys are still available in the apps or desktop clients, then remember to delete the keys also locally on the other devices.",
+    "Any still connected device might cause problems after deleting the keys, so it is better to disconnect and reconnect the devices again." : "Alternatively, after key reset, you can also set the apps to initial state and reconnect to your MagentaCLOUD account.",
+    "Confirm and reset End-to-End encryption" : "Confirm and reset",
+    "This is the final warning: Do you really want to reset your keys?" : "This the final warning: Do you really want to reset your encryption. Encrypted data are lost and will be deleted.",
+    "End-to-End encryption is currently enabled and correctly setup." : "End to end encryption is currently enabled.",
     "Cancel" : "Cancel",
     "Confirm" : "Confirm",
     "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients."


### PR DESCRIPTION
Add custom translations for end_to_end_encryption app, based on standard Nextcloud labels to avoid extra code customizations.