### PR TITLE
 (nmc 2480 v25stable) fix logo position and footer width

### DIFF
--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -27,7 +27,8 @@ footer[role="contentinfo"] {
     right: 16px;
     bottom: 0; 
     max-height: var(--telekom-spacing-baseline-space-3);
-    max-width: 95.5vw;
+    max-width: 95.25vw;
+    min-width: 94.6vw;
     z-index: 998;
     border-radius: 0px 0px 8px 8px;
 

--- a/css/layouts/header.scss
+++ b/css/layouts/header.scss
@@ -52,7 +52,7 @@ header {
 			position: initial;
 			width: 60px;
 			height: 60px;
-			border-radius: 8px 0px 0px 0px;
+			padding-left: 32px;
 
 		}
 		.title {

--- a/css/layouts/user.scss
+++ b/css/layouts/user.scss
@@ -16,7 +16,7 @@
 #content {
     position: fixed;
     inset: -0.5rem 16px 0 0;
-    width: 98vw;
+    width: 98%;
     border-radius: 0;
     margin: 16px;
 }


### PR DESCRIPTION
Fixed header logo position and footer width as discussed in review call 7.8. 
Footer width changes with window resize, which does not apply to either #header or #content, so a longterm suggestion might be to rethink how footer is being displayed altogether, maybe with a position: relative to the entire screen (in that case need position from design maybe, and even in that case scrolling through the content would mean footer always stays on top at the bottom of the screen).

![Screenshot 2023-09-08 094047](https://github.com/nextmcloud/nmctheme/assets/143171366/3abfe9f8-b9b7-48ac-b6ee-0aed5128659d)
