### PR TITLE
Change photos app navigation entry to Medien/Media

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -114,6 +114,9 @@
   "text": { "translations": {
     "Add Link": "Link hinzufügen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
+  "photos": { "translations": {
+    "Photos": "Fotos"
+  },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "nmctheme": { "translations": {
     "Copyright": " Telekom Deutschland GmbH",
     "OpenSource": "Open Source Lizenzen",
@@ -128,5 +131,7 @@
     "Customer Center": "Kundencenter",
     "Help & FAQ": "Hilfe & FAQ",
     "Account Settings": "Einstellungen",
+    "Display settings": "Anzeigeeinstellungen",
+    "PhotosMedia": "Medien"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -114,6 +114,9 @@
   "text": { "translations": {
     "Add Link": "Link hinzufügen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
+  "photos": { "translations": {
+    "Photos": "Fotos"
+  },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "nmctheme": { "translations": {
     "Copyright": "©Telekom Deutschland GmbH",
     "OpenSource": "Open Source Lizenzen",
@@ -128,5 +131,7 @@
     "Customer Center": "Kundencenter",
     "Help & FAQ": "Hilfe & FAQ",
     "Account Settings": "Einstellungen",
+    "Display settings": "Anzeigeeinstellungen",
+    "PhotosMedia": "Medien"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -113,7 +113,10 @@
     },"pluralForm" :"nplurals=2; plural=(n != 1);"},
     "text": { "translations": {
         "Add Link": "Add Link"
-      },"pluralForm" :"nplurals=2; plural=(n != 1);"},
+    },"pluralForm" :"nplurals=2; plural=(n != 1);"},
+    "photos": { "translations": {
+        "Photos": "Fotos"
+    },"pluralForm" :"nplurals=2; plural=(n != 1);"},
     "nmctheme": { "translations": {
         "Copyright": "©Telekom Deutschland GmbH",
         "OpenSource": "Open Source licenses",
@@ -128,5 +131,7 @@
       "Customer Center": "Customer Center",
       "Help & FAQ": "Help & FAQ",
       "Account Settings": "Account Settings",
+        "Display settings": "Display settings",
+        "PhotosMedia": "Media"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -113,7 +113,10 @@
     },"pluralForm" :"nplurals=2; plural=(n != 1);"},
     "text": { "translations": {
         "Add Link": "Add Link"
-      },"pluralForm" :"nplurals=2; plural=(n != 1);"},
+    },"pluralForm" :"nplurals=2; plural=(n != 1);"},
+    "photos": { "translations": {
+        "Photos": "Fotos"
+    },"pluralForm" :"nplurals=2; plural=(n != 1);"},
     "nmctheme": { "translations": {
         "Copyright": "©Telekom Deutschland GmbH",
         "OpenSource": "Open Source licenses",
@@ -128,5 +131,7 @@
       "Customer Center": "Customer Center",
       "Help & FAQ": "Help & FAQ",
       "Account Settings": "Account Settings",
+        "Display settings": "Display settings",
+        "PhotosMedia": "Media"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -91,7 +91,8 @@ class FactoryDecorator implements IFactory {
 
 		$l10nFilenames = $this->decoratedFactory->getL10nFilesForApp("nmctheme", $lang);
 		if (!empty($l10nFilenames)) {
-			$json = json_decode(file_get_contents($l10nFilenames[0]), true);
+			$filename = $l10nFilenames[0];
+			$json = json_decode(file_get_contents($filename), true);
 			if (!\is_array($json)) {
 				$jsonError = json_last_error();
 				\OC::$server->getLogger()->warning("Failed to load $filename - json error code: $jsonError", ['app' => 'l10n']);

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -13,24 +13,52 @@ namespace OCA\NMCTheme\Listener;
 
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OCA\Theming\Util;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-
+use OCP\IL10N;
+use OCP\INavigationManager;
 use OCP\IURLGenerator;
 
 class BeforeTemplateRenderedListener implements IEventListener {
 	private IURLGenerator $urlGenerator;
 	private ContentSecurityPolicyNonceManager $nonceManager;
 	private Util $themingUtil;
+	private INavigationManager $navManager;
+	private IL10N $l;
 
 	public function __construct(
 		IURLGenerator $urlGenerator,
 		ContentSecurityPolicyNonceManager $nonceManager,
-		Util $themingUtil
-	) {
+		Util $themingUtil,
+		INavigationManager $navManager,
+		IL10N $l) {
 		$this->urlGenerator = $urlGenerator;
 		$this->nonceManager = $nonceManager;
 		$this->themingUtil = $themingUtil;
+		$this->navManager = $navManager;
+		$this->l = $l;
+	}
+
+	/**
+	 * FIXME The navigation bar entry for Photos app has label photos, but the app
+	 * is also managing videos. Unfortunately, changing the translations for Photos to
+	 * Media also changes
+	 *
+	 * The final fix in photos app should change the folder name with separate labels
+	 * for appname and
+	 *
+	 * Meanwhile, we can "teach" the navigation manager to rename photos app in menu.
+	 */
+	protected function fixPhotosAppName() {
+		if ($this->navManager !== null) {
+			$entries = $this->navManager->getAll();
+			if (array_key_exists('photos', $entries)) {
+				$entry = $entries['photos'];
+				$entry['name'] = $this->l->t('PhotosMedia');
+				$this->navManager->add($entry); // this also replaces entries ;-)
+			}
+		}
 	}
 
 	/**
@@ -40,6 +68,12 @@ class BeforeTemplateRenderedListener implements IEventListener {
 	 */
 	public function handle(Event $event): void {
 		$response = $event->getResponse();
+
+		// FIXME as long as photos app has photos as internal label and appname label
+		if ($response->getRenderAs() === TemplateResponse::RENDER_AS_USER ||
+			 $response->getRenderAs() === TemplateResponse::RENDER_AS_PUBLIC) {
+			$this->fixPhotosAppName();
+		}
 
 		if (($response->getStatus() >= 400) && ($response->getStatus() < 600)) {
 			// render client error states with own layout => own #body-status id


### PR DESCRIPTION
Fix temporary the app name of photos to emphasize media focus of app.

Photos app uses the label "Photos" as the name of the photos category within the app
AND add the navigation entry for the app. As the app also offers video management,
our PO wants a different name for the menu entry ("Media"), but this would also change the
name of the Photos category with the app.

We temporarily fix this by changing the nav entry to PhotosMedia before rendering public/user page.