### PR TITLE
add alignment for arrow button, chkboxes and chkbox text

### DIFF
--- a/css/components/ncappnavigation.scss
+++ b/css/components/ncappnavigation.scss
@@ -132,3 +132,8 @@ $breakpoint-mobile: 1024px;
 		}
 	}
 }
+
+// align arrow button to be centered with checkboxes in display settings 
+#app-settings > .files-settings > .display-settings > #display-settings-btn {
+	margin-left: -2px;
+}

--- a/css/components/nccheckbox.scss
+++ b/css/components/nccheckbox.scss
@@ -1,4 +1,20 @@
 span.checkbox-radio-switch.checkbox-radio-switch-checkbox {
+	// align left both checked and unchecked icons with loading bar in files-settings div
+	& > .checkbox-radio-switch__label > .checkbox-radio-switch__icon > .material-design-icon {
+		&.checkbox-blank-outline-icon {
+			margin-left: -3px;
+		}
+
+		&.checkbox-marked-icon {
+			margin-left: -3px;
+		}
+	}
+
+	// Align text left of checboxes with the Display Settings text left to the arrow button on top
+	& .checkbox-radio-switch__label > .checkbox-radio-switch__label-text {
+		margin-left: -1px;
+	}
+	
 	// do not set background color when on hover
 	&:not(.checkbox-radio-switch--disabled) {
 		.checkbox-radio-switch__label:hover, .checkbox-radio-switch__label:focus-within {


### PR DESCRIPTION
To rebase from main and merge after https://github.com/nextmcloud/nmctheme/pull/65 is merged

- align checkboxes left with the navigation bar
- align checkboxes centered with the arrow of the open/close flip arrow
- align text right of checkboxes with the text right side of the open/close flip arrow

![WIP 8](https://github.com/nextmcloud/nmctheme/assets/143171366/66af61dc-f238-4458-8610-a7b8f73ce3d9)
![navbar alignment](https://github.com/nextmcloud/nmctheme/assets/143171366/d82dd0fa-b25c-43ef-a81a-198bbce1bc92)
