### PR TITLE
Fix log error message on invalid L10N json

### DIFF
--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -94,8 +94,8 @@ class FactoryDecorator implements IFactory {
 			$filename = $l10nFilenames[0];
 			$json = json_decode(file_get_contents($filename), true);
 			if (!\is_array($json)) {
-				$jsonError = json_last_error();
-				\OC::$server->getLogger()->warning("Failed to load $filename - json error code: $jsonError", ['app' => 'l10n']);
+				$jsonError = json_last_error() . '-' . json_last_error_msg();
+				\OC::$server->getLogger()->warning("Failed to load $filename - json error: $jsonError", ['app' => 'l10n']);
 			} else {
 				$overrides = $json;
 			}

--- a/tests/unit/L10N/DecoratorTest.php
+++ b/tests/unit/L10N/DecoratorTest.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 namespace OCA\NMCTheme\Test\L10N;
 
-use OCA\NMCTheme\Controller\AppendController;
+use OCA\NMCTheme\Controller\L10NAppendController;
 use OCA\NMCTheme\L10N\FactoryDecorator;
 use OCP\App\IAppManager;
 use OCP\IRequest;
@@ -71,6 +71,17 @@ class DecoratorTest extends TestCase {
 		$this->nmcFactory = $this->app->getContainer()->get(IFactory::class);
 		$this->assertInstanceOf(FactoryDecorator::class, $this->nmcFactory);
 	}
+
+    /**
+     * Check the readability of the translation files
+     */
+    public function testJsonLoad(): void {
+        foreach ($this->langFiles as $filename) {
+            $json = json_decode(file_get_contents($this->l10nPath . '/' . $filename), true);
+            $lastErr = json_last_error();
+            $this->assertEquals(0, $lastErr, "json problem: " . $lastErr . "-" . json_last_error_msg());
+        }
+    }
 
 
 	/**
@@ -133,7 +144,7 @@ class DecoratorTest extends TestCase {
 
 
 	public function testL10NAppendControllerCreate() {
-		new AppendController(
+		new L10NAppendController(
 			$this->app->getContainer()->get(IRequest::class),
 			$this->app->getContainer()->get(FactoryDecorator::class)
 		);

--- a/tests/unit/L10N/DecoratorTest.php
+++ b/tests/unit/L10N/DecoratorTest.php
@@ -72,16 +72,16 @@ class DecoratorTest extends TestCase {
 		$this->assertInstanceOf(FactoryDecorator::class, $this->nmcFactory);
 	}
 
-    /**
-     * Check the readability of the translation files
-     */
-    public function testJsonLoad(): void {
-        foreach ($this->langFiles as $filename) {
-            $json = json_decode(file_get_contents($this->l10nPath . '/' . $filename), true);
-            $lastErr = json_last_error();
-            $this->assertEquals(0, $lastErr, "json problem: " . $lastErr . "-" . json_last_error_msg());
-        }
-    }
+	/**
+	 * Check the readability of the translation files
+	 */
+	public function testJsonLoad(): void {
+		foreach ($this->langFiles as $filename) {
+			$json = json_decode(file_get_contents($this->l10nPath . '/' . $filename), true);
+			$lastErr = json_last_error();
+			$this->assertEquals(0, $lastErr, "json problem: " . $lastErr . "-" . json_last_error_msg());
+		}
+	}
 
 
 	/**

--- a/tests/unit/L10N/FactoryTest.php
+++ b/tests/unit/L10N/FactoryTest.php
@@ -55,6 +55,7 @@ class FactoryTest extends TestCase {
 		$this->serverRoot = \OC::$SERVERROOT;
 
 		$this->config
+        ->expects(self::any())
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, true],

--- a/tests/unit/L10N/FactoryTest.php
+++ b/tests/unit/L10N/FactoryTest.php
@@ -55,7 +55,7 @@ class FactoryTest extends TestCase {
 		$this->serverRoot = \OC::$SERVERROOT;
 
 		$this->config
-        ->expects(self::any())
+		->expects(self::any())
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, true],


### PR DESCRIPTION
This PR fixes the exception on logging invalid appender L10N json files.
It now also delivers the error message.

A unittest is added that checks for syntactically valid L10N appender jons.