### PR TITLE
Move translation from settings to theme

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -124,7 +124,7 @@
     "Data protection": "Datenschutz",
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
-    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}%% belegt",
+    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}% belegt",
     "Display settings": "Anzeigeeinstellungen",
     "PhotosMedia": "Medien"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -125,13 +125,13 @@
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
     "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}%% belegt",
-    "Display settings": "Anzeigeeinstellungen"
+    "Display settings": "Anzeigeeinstellungen",
+    "PhotosMedia": "Medien"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "nmcsettings": { "translations": {
     "Customer Center": "Kundencenter",
     "Help & FAQ": "Hilfe & FAQ",
     "Account Settings": "Einstellungen",
-    "Display settings": "Anzeigeeinstellungen",
-    "PhotosMedia": "Medien"
+    "Display settings": "Anzeigeeinstellungen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -124,7 +124,7 @@
     "Data protection": "Datenschutz",
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
-    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}%% belegt",
+    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}% belegt",
     "Display settings": "Anzeigeeinstellungen",
     "PhotosMedia": "Medien"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -125,13 +125,13 @@
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
     "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}%% belegt",
-    "Display settings": "Anzeigeeinstellungen"
+    "Display settings": "Anzeigeeinstellungen",
+    "PhotosMedia": "Medien"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "nmcsettings": { "translations": {
     "Customer Center": "Kundencenter",
     "Help & FAQ": "Hilfe & FAQ",
     "Account Settings": "Einstellungen",
-    "Display settings": "Anzeigeeinstellungen",
-    "PhotosMedia": "Medien"
+    "Display settings": "Anzeigeeinstellungen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -124,7 +124,7 @@
         "Data protection": "Data protection",
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
-        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%%",
+        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%",
         "Display settings": "Display settings",
         "PhotosMedia": "Media"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"},

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -125,13 +125,13 @@
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
         "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%%",
-        "Display settings": "Display settings"
+        "Display settings": "Display settings",
+        "PhotosMedia": "Media"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"},
     "nmcsettings": { "translations": {
       "Customer Center": "Customer Center",
       "Help & FAQ": "Help & FAQ",
       "Account Settings": "Account Settings",
-        "Display settings": "Display settings",
-        "PhotosMedia": "Media"
+        "Display settings": "Display settings"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -124,7 +124,7 @@
         "Data protection": "Data protection",
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
-        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%%",
+        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%",
         "Display settings": "Display settings",
         "PhotosMedia": "Media"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"},

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -125,13 +125,13 @@
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
         "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%%",
-        "Display settings": "Display settings"
+        "Display settings": "Display settings",
+        "PhotosMedia": "Media"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"},
     "nmcsettings": { "translations": {
       "Customer Center": "Customer Center",
       "Help & FAQ": "Help & FAQ",
       "Account Settings": "Account Settings",
-        "Display settings": "Display settings",
-        "PhotosMedia": "Media"
+        "Display settings": "Display settings"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }


### PR DESCRIPTION
Due to a merge fault, translation for Photos -> Media app are shifted to nmcsetting translations.
Shifting back should fix the problem.