### PR TITLE
created newfilemenu plugin

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -94,6 +94,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		// keep src for future use:   \OCP\Util::addScript("nmctheme", "../dist/l10nappender");
 		\OCP\Util::addScript("nmctheme", "../dist/mimetypes", "core");
 		\OCP\Util::addScript('nmctheme', '../dist/nmcfooter', 'theming');
+		\OCP\Util::addScript("nmctheme", "../dist/newfilemenuplugin");
 		\OCP\Util::addScript("nmctheme", "../dist/filelistplugin");
 		\OCP\Util::addScript("nmctheme", "../dist/filessettings");
 		\OCP\Util::addScript("nmctheme", "../dist/nmcsettings");

--- a/src/js/filelistplugin.js
+++ b/src/js/filelistplugin.js
@@ -59,7 +59,7 @@
 					}
 
 					if (summary.totalSize > 0) {
-						selection += ' (' + OC.Util.humanFileSize(summary.totalSize) + ')'
+						selection += ' (' + OC.Util.humanFileSize(summary.totalSize) + ')' // eslint-disable-line
 					}
 
 					fileTable.find('.column-name a.name > span:first').text(selection)

--- a/src/js/newfilemenuplugin.js
+++ b/src/js/newfilemenuplugin.js
@@ -16,7 +16,7 @@
 				// Trigger upload action also with keyboard navigation on enter
 				this.$el.find('[for="file_upload_start"]').on('keyup', function(event) {
 					if (event.key === ' ' || event.key === 'Enter') {
-						$('#file_upload_start').trigger('click')
+						$('#file_upload_start').trigger('click') // eslint-disable-line
 					}
 				})
 
@@ -24,7 +24,7 @@
 				folderEntry.removeClass('menuitem').addClass('customitem')
 
 				folderEntry.on('click', function(event) {
-					let $target = $(event.target)
+					let $target = $(event.target) // eslint-disable-line
 
 					if (!$target.hasClass('menuitem')) {
 						$target = $target.closest('.customitem')

--- a/src/js/newfilemenuplugin.js
+++ b/src/js/newfilemenuplugin.js
@@ -10,34 +10,34 @@
 				this.$el.html(this.template({
 					uploadMaxHumanFileSize: 'TODO',
 					uploadLabel: t('files', 'Upload file'),
-					items: this._menuItems
-				}));
-	
+					items: this._menuItems,
+				}))
+
 				// Trigger upload action also with keyboard navigation on enter
 				this.$el.find('[for="file_upload_start"]').on('keyup', function(event) {
-					if (event.key === " " || event.key === "Enter") {
-						$('#file_upload_start').trigger('click');
+					if (event.key === ' ' || event.key === 'Enter') {
+						$('#file_upload_start').trigger('click')
 					}
-				});
-				
-				let folderEntry = this.$el.find('[data-action="folder"]')
+				})
+
+				const folderEntry = this.$el.find('[data-action="folder"]')
 				folderEntry.removeClass('menuitem').addClass('customitem')
 
 				folderEntry.on('click', function(event) {
-					let $target = $(event.target);
+					let $target = $(event.target)
 
 					if (!$target.hasClass('menuitem')) {
-						$target = $target.closest('.customitem');
+						$target = $target.closest('.customitem')
 					}
 
-					const name = $target.attr('data-templatename');
+					const name = $target.attr('data-templatename')
 					const uniqueName = self.fileList.getUniqueName(name)
-		
-					let tempPromise = self.fileList.createDirectory(uniqueName)
+
+					const tempPromise = self.fileList.createDirectory(uniqueName)
 					Promise.all([tempPromise]).then(() => {
 						self.fileList.rename(uniqueName)
 					})
-				});
+				})
 			}
 		},
 	}

--- a/src/js/newfilemenuplugin.js
+++ b/src/js/newfilemenuplugin.js
@@ -1,0 +1,46 @@
+(function() {
+
+	const NewFileMenuPlugin = {
+
+		attach(menu) {
+
+			menu.render = function() {
+				const self = this
+
+				this.$el.html(this.template({
+					uploadMaxHumanFileSize: 'TODO',
+					uploadLabel: t('files', 'Upload file'),
+					items: this._menuItems
+				}));
+	
+				// Trigger upload action also with keyboard navigation on enter
+				this.$el.find('[for="file_upload_start"]').on('keyup', function(event) {
+					if (event.key === " " || event.key === "Enter") {
+						$('#file_upload_start').trigger('click');
+					}
+				});
+				
+				let folderEntry = this.$el.find('[data-action="folder"]')
+				folderEntry.removeClass('menuitem').addClass('customitem')
+
+				folderEntry.on('click', function(event) {
+					let $target = $(event.target);
+
+					if (!$target.hasClass('menuitem')) {
+						$target = $target.closest('.customitem');
+					}
+
+					const name = $target.attr('data-templatename');
+					const uniqueName = self.fileList.getUniqueName(name)
+		
+					let tempPromise = self.fileList.createDirectory(uniqueName)
+					Promise.all([tempPromise]).then(() => {
+						self.fileList.rename(uniqueName)
+					})
+				});
+			}
+		},
+	}
+
+	OC.Plugins.register('OCA.Files.NewFileMenu', NewFileMenuPlugin)
+})()

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -4,6 +4,7 @@ const path = require('path')
 module.exports = {
 	entry: {
 		filelistplugin: './src/js/filelistplugin.js',
+		newfilemenuplugin: './src/js/newfilemenuplugin.js',
 		filessettings: './src/js/filessettings.js',
 		nmcsettings: './src/js/nmcsettings.js',
 		// keep src for future use: l10nappender: './src/l10nappender.ts',


### PR DESCRIPTION
changed the function to add a folder: the folder will be created called "New folder" or "Neuer Ordner" with an activated rename function
if the created folder is not inside the viewport, the screen will scroll down to the created item
if a folder called "Neuer Ordner" or "New folder" already exists, the created folder will have a counter like "New folder (2)