### PR TITLE
Restrict supported languages in theme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,15 @@ $CONFIG = array (
 );
 ----
 
+.Restriction of supported languages (optional, example on some en and de locales)
+----
+<?php
+$CONFIG = array (
+    'default_language' => 'de_DE',
+    'nmc_supported_locales' => array(0 => 'en', 1 => 'en_GB', 2 => 'de', 3 => 'de_DE');
+);
+----
+
 .Nextcloud standard *theming* app configs
 ----
 # Set base url of the installation

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -19,41 +19,41 @@ use OCP\L10N\IFactory;
 use OCP\L10N\ILanguageIterator;
 
 class LanguageIteratorDecorator implements ILanguageIterator {
-    private ILanguageIterator $decorated;
-    private array $supported_locales = [];
+	private ILanguageIterator $decorated;
+	private array $supported_locales = [];
 
-    public function __construct(ILanguageIterator $decorated,
-                                array $supported_locales) {
-        $this->decorated = $decorated;
-        $this->supported_locales = $supported_locales;
-    }
+	public function __construct(ILanguageIterator $decorated,
+		array $supported_locales) {
+		$this->decorated = $decorated;
+		$this->supported_locales = $supported_locales;
+	}
 
-    public function rewind(): void {
+	public function rewind(): void {
 		$this->decorated->rewind();
 	}
 
-    public function current(): string {
-    	$locale = $this->decorated->rewind();
-        
-        if (empty($this->supported_locales) ||
-            in_array($locale, $this->supported_locales)) {
-            return $locale;
-        } else {
-            return 'en';
-        }
-    }
+	public function current(): string {
+		$locale = $this->decorated->rewind();
+		
+		if (empty($this->supported_locales) ||
+			in_array($locale, $this->supported_locales)) {
+			return $locale;
+		} else {
+			return 'en';
+		}
+	}
 
-    public function next(): bool {
-        return $this->decorated->next();
-    }
+	public function next(): bool {
+		return $this->decorated->next();
+	}
 
-    public function key(): int {
-        return $this->decorated->key();
-    }
+	public function key(): int {
+		return $this->decorated->key();
+	}
 
-    public function valid(): bool {
-        return $this->decorated->valid();
-    }
+	public function valid(): bool {
+		return $this->decorated->valid();
+	}
 
 }
 
@@ -84,13 +84,13 @@ class FactoryDecorator implements IFactory {
 	protected array $overrides = [];
 
 
-    /**
-     * NMCTheme restricts the available locales and translations
-     * to only a selectable set
-     * @var string[]  
-     * 
-     */
-    protected array $supported_locales = [];
+	/**
+	 * NMCTheme restricts the available locales and translations
+	 * to only a selectable set
+	 * @var string[]
+	 *
+	 */
+	protected array $supported_locales = [];
 
 
 	/**
@@ -103,63 +103,63 @@ class FactoryDecorator implements IFactory {
 		$this->config = $config;
 		$this->decoratedFactory = $decoratedFactory;
 
-        // configuration for supported locales of nmctheme
-        $supportedLocales = $this->config->getSystemValue('nmc_supported_locales', false);
-        if (is_array($supportedLocales)) {
-            // the default en must be always supported
-            $this->supported_locales = array_unique(array_merge($supportedLocales, ['en', 'en_GB']));
-        }
+		// configuration for supported locales of nmctheme
+		$supportedLocales = $this->config->getSystemValue('nmc_supported_locales', false);
+		if (is_array($supportedLocales)) {
+			// the default en must be always supported
+			$this->supported_locales = array_unique(array_merge($supportedLocales, ['en', 'en_GB']));
+		}
 	}
 
-    public function getDecorated() :Factory {
-        return $this->decoratedFactory;
-    }
+	public function getDecorated() :Factory {
+		return $this->decoratedFactory;
+	}
 
-    /**
-     * Filter by supported locales (if set)
-     */
-    protected function filterLocale(string $locale) {
-        if (empty($this->supported_locales) ||
-            in_array($locale, $this->supported_locales)) {
-            return $locale;
-        } else {
-            return 'en';
-        }
-    }
+	/**
+	 * Filter by supported locales (if set)
+	 */
+	protected function filterLocale(string $locale) {
+		if (empty($this->supported_locales) ||
+			in_array($locale, $this->supported_locales)) {
+			return $locale;
+		} else {
+			return 'en';
+		}
+	}
 
-    /**
-     * Filter a set of supported locales (if set)
-     */
-    protected function filterLocales(array $locales) {
-        if (empty($this->supported_locales)) {
-            return $locales;
-        }
+	/**
+	 * Filter a set of supported locales (if set)
+	 */
+	protected function filterLocales(array $locales) {
+		if (empty($this->supported_locales)) {
+			return $locales;
+		}
 
 
-        $filteredLocales = array_filter($locales, function($locale) {
-            return in_array($locale['code'], $this->supported_locales);
-        });
-        
-        if (empty($this->supported_locales) ||
-            empty($filteredLocales)) {
-            return ['en'];
-        } else {
-            // make sure that indexed are corrected
-            return array_values($filteredLocales);
-        }
-    }
+		$filteredLocales = array_filter($locales, function ($locale) {
+			return in_array($locale['code'], $this->supported_locales);
+		});
+		
+		if (empty($this->supported_locales) ||
+			empty($filteredLocales)) {
+			return ['en'];
+		} else {
+			// make sure that indexed are corrected
+			return array_values($filteredLocales);
+		}
+	}
 
-    /**
-     * Predicate to check filter
-     */
-    protected function isSupportedLocale(string $locale) {
-        return (empty($this->supported_locales) || 
-                in_array($locale, $this->supported_locales));
-    }
+	/**
+	 * Predicate to check filter
+	 */
+	protected function isSupportedLocale(string $locale) {
+		return (empty($this->supported_locales) ||
+				in_array($locale, $this->supported_locales));
+	}
 
 	/**
 	 * Read all the available translation jsons for app.
-     * This is not part of the interface IFactory
+	 * This is not part of the interface IFactory
 	 *
 	 * @param string $app
 	 * @param string $lang
@@ -167,13 +167,13 @@ class FactoryDecorator implements IFactory {
 	 */
 	public function getTranslationsForApp($app, $lang) {
 
-        // if language is not suppported - not translations
-        if (!$this->isSupportedLocale($lang)) {
-            return [];
-        }
+		// if language is not suppported - not translations
+		if (!$this->isSupportedLocale($lang)) {
+			return [];
+		}
 
-        $translations = [];
-        $l10nFilenames = $this->decoratedFactory->getL10nFilesForApp($app, $lang);
+		$translations = [];
+		$l10nFilenames = $this->decoratedFactory->getL10nFilesForApp($app, $lang);
 		foreach ($l10nFilenames as $filename) {
 			$json = json_decode(file_get_contents($filename), true);
 			if (!\is_array($json)) {
@@ -193,8 +193,8 @@ class FactoryDecorator implements IFactory {
 			$this->overrides[$lang] = $this->getOverrides($lang);
 		}
 
-        $overrides = $this->overrides[$lang][$app] ?? [];
-        return array_merge($translations, $overrides);
+		$overrides = $this->overrides[$lang][$app] ?? [];
+		return array_merge($translations, $overrides);
 	}
 
 	/**
@@ -336,11 +336,11 @@ class FactoryDecorator implements IFactory {
 	 * @see private\L10N\Factory
 	 */
 	public function languageExists($app, $lang) {
-        if (!$this->isSupportedLocale($lang)) {
-            return false;
-        }
+		if (!$this->isSupportedLocale($lang)) {
+			return false;
+		}
 
-        return $this->decoratedFactory->languageExists($app, $lang);
+		return $this->decoratedFactory->languageExists($app, $lang);
 	}
 
 	/**
@@ -349,9 +349,9 @@ class FactoryDecorator implements IFactory {
 	 * @see private\L10N\Factory
 	 */
 	public function localeExists($locale) {
-        if (!$this->isSupportedLocale($locale)) {
-            return false;
-        }
+		if (!$this->isSupportedLocale($locale)) {
+			return false;
+		}
 
 		return $this->decoratedFactory->localeExists($locale);
 	}
@@ -361,10 +361,10 @@ class FactoryDecorator implements IFactory {
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
-    public function getLanguageIterator(IUser $user = null): ILanguageIterator {
-        return new LanguageIteratorDecorator(
-            $this->decoratedFactory->getLanguageIterator($user),
-            $this->supported_locales);
+	public function getLanguageIterator(IUser $user = null): ILanguageIterator {
+		return new LanguageIteratorDecorator(
+			$this->decoratedFactory->getLanguageIterator($user),
+			$this->supported_locales);
 	}
 
 	/**
@@ -375,18 +375,18 @@ class FactoryDecorator implements IFactory {
 	public function getLanguages(): array {
 		$languages = $this->decoratedFactory->getLanguages();
 
-        if (empty($this->supported_locales)) {
-            return $languages;
-        }
+		if (empty($this->supported_locales)) {
+			return $languages;
+		}
 
-        $commonLanguages = array_filter($languages['commonLanguages'], function($lang) { 
-                return in_array($lang['code'], $this->supported_locales);
-            });
-        $otherLanguages = array_filter($languages['otherLanguages'], function($lang) { 
-                return in_array($lang['code'], $this->supported_locales);
-            });
-        return [
-            // re-index filtered arrays
+		$commonLanguages = array_filter($languages['commonLanguages'], function ($lang) {
+			return in_array($lang['code'], $this->supported_locales);
+		});
+		$otherLanguages = array_filter($languages['otherLanguages'], function ($lang) {
+			return in_array($lang['code'], $this->supported_locales);
+		});
+		return [
+			// re-index filtered arrays
 			'commonLanguages' => array_values($commonLanguages),
 			'otherLanguages' => array_values($otherLanguages)
 		];

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -18,6 +18,46 @@ use OCP\IUser;
 use OCP\L10N\IFactory;
 use OCP\L10N\ILanguageIterator;
 
+class LanguageIteratorDecorator implements ILanguageIterator {
+    private ILanguageIterator $decorated;
+    private array $supported_locales = [];
+
+    public function __construct(ILanguageIterator $decorated,
+                                array $supported_locales) {
+        $this->decorated = $decorated;
+        $this->supported_locales = $supported_locales;
+    }
+
+    public function rewind(): void {
+		$this->decorated->rewind();
+	}
+
+    public function current(): string {
+    	$locale = $this->decorated->rewind();
+        
+        if (empty($this->supported_locales) ||
+            in_array($locale, $this->supported_locales)) {
+            return $locale;
+        } else {
+            return 'en';
+        }
+    }
+
+    public function next(): bool {
+        return $this->decorated->next();
+    }
+
+    public function key(): int {
+        return $this->decorated->key();
+    }
+
+    public function valid(): bool {
+        return $this->decorated->valid();
+    }
+
+}
+
+
 class FactoryDecorator implements IFactory {
 	private Factory $decoratedFactory;
 
@@ -43,6 +83,16 @@ class FactoryDecorator implements IFactory {
 	 */
 	protected array $overrides = [];
 
+
+    /**
+     * NMCTheme restricts the available locales and translations
+     * to only a selectable set
+     * @var string[]  
+     * 
+     */
+    protected array $supported_locales = [];
+
+
 	/**
 	 * @param IConfig $config
 	 */
@@ -52,19 +102,69 @@ class FactoryDecorator implements IFactory {
 	) {
 		$this->config = $config;
 		$this->decoratedFactory = $decoratedFactory;
+
+        // configuration for supported locales of nmctheme
+        $supportedLocales = $this->config->getSystemValue('nmc_supported_locales', false);
+        if (is_array($supportedLocales)) {
+            // the default en must be always supported
+            $this->suppported_locales = array_unique(array_merge($supportedLocales, ['en']));
+        }
 	}
+
+
+    /**
+     * Filter by supported locales (if set)
+     */
+    protected function filterLocale(string $locale) {
+        if (empty($this->supported_locales) ||
+            in_array($locale, $this->supported_locales)) {
+            return $locale;
+        } else {
+            return 'en';
+        }
+    }
+
+    /**
+     * Filter a set of supported locales (if set)
+     */
+    protected function filterLocales(array $locales) {
+        if (empty($this->supported_locales)) {
+            return $locales;
+        }
+
+        $filteredLocales = array_intersect($locales, $this->supported_locales);
+        if (empty($this->supported_locales)) {
+            return ['en'];
+        } else {
+            // make sure that indexed are corrected
+            return array_values($filteredLocales);
+        }
+    }
+
+    /**
+     * Predicate to check filter
+     */
+    protected function isSupportedLocale(string $locale) {
+        return (empty($this->supported_locales) || 
+                in_array($locale, $this->supported_locales));
+    }
 
 	/**
 	 * Read all the available translation jsons for app.
-	 *
 	 *
 	 * @param string $app
 	 * @param string $lang
 	 * @return string[]
 	 */
 	public function getTranslationsForApp($app, $lang) {
-		$translations = [];
-		$l10nFilenames = $this->decoratedFactory->getL10nFilesForApp($app, $lang);
+
+        // if language is not suppported - not translations
+        if (!$this->isSupportedLocale($lang)) {
+            return [];
+        }
+
+        $translations = [];
+        $l10nFilenames = $this->decoratedFactory->getL10nFilesForApp($app, $lang);
 		foreach ($l10nFilenames as $filename) {
 			$json = json_decode(file_get_contents($filename), true);
 			if (!\is_array($json)) {
@@ -76,7 +176,8 @@ class FactoryDecorator implements IFactory {
 				}
 			}
 		}
-		return $translations;
+        
+        return $translations;
 	}
 
 	/**
@@ -167,102 +268,128 @@ class FactoryDecorator implements IFactory {
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findLanguage(?string $appId = null): string {
-		return $this->decoratedFactory->findLanguage($appId);
+		return $this->filterLocale($this->decoratedFactory->findLanguage($appId));
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findGenericLanguage(string $appId = null): string {
-		return $this->decoratedFactory->findGenericLanguage($appId);
+		return $this->filterLocale($this->decoratedFactory->findGenericLanguage($appId));
 	}
 	
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findLocale($lang = null) {
-		return $this->decoratedFactory->findLocale($lang);
+		return $this->filterLocale($this->decoratedFactory->findLocale($lang));
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findLanguageFromLocale(string $app = 'core', string $locale = null) {
-		return $this->decoratedFactory->findLanguageFromLocale($app, $locale);
+		return $this->filterLocale($this->decoratedFactory->findLanguageFromLocale($app, $locale));
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findAvailableLanguages($app = null): array {
-		return $this->decoratedFactory->findAvailableLanguages($app);
+		return $this->filterLocales($this->decoratedFactory->findAvailableLanguages($app));
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findAvailableLocales() {
-		return $this->decoratedFactory->findAvailableLocales();
+		return $this->filterLocales($this->decoratedFactory->findAvailableLocales());
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function languageExists($app, $lang) {
-		return $this->decoratedFactory->languageExists($app, $lang);
+        if (!$this->isSupportedLocale($lang)) {
+            return false;
+        }
+
+        return $this->decoratedFactory->languageExists($app, $lang);
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function localeExists($locale) {
+        if (!$this->isSupportedLocale($locale)) {
+            return false;
+        }
+
 		return $this->decoratedFactory->localeExists($locale);
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
-	public function getLanguageIterator(IUser $user = null): ILanguageIterator {
-		return $this->decoratedFactory->getLanguageIterator($user);
+    public function getLanguageIterator(IUser $user = null): ILanguageIterator {
+        return new LanguageIteratorDecorator(
+            $this->decoratedFactory->getLanguageIterator($user),
+            $this->supported_locales);
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function getLanguages(): array {
-		return $this->decoratedFactory->getLanguages();
+		$languages = $this->decoratedFactory->getLanguages();
+
+        if (empty($this->supported_locales)) {
+            return $languages;
+        }
+
+        $commonLanguages = array_filter($languages['commonLanguages'], function($lang) { 
+                return in_array($lang['code'], $this->supported_locales);
+            });
+        $otherLanguages = array_filter($languages['otherLanguages'], function($lang) { 
+                return in_array($lang['code'], $this->supported_locales);
+            });
+        return [
+            // re-index filtered arrays
+			'commonLanguages' => array_values($commonLanguages),
+			'otherLanguages' => array_values($otherLanguages)
+		];
 	}
 
 	/**
-	 * No decoration, just pass on to original IFactory
+	 * decorate standard IFactory with supported locale filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function getUserLanguage(IUser $user = null): string {
-		return $this->decoratedFactory->getUserLanguage($user);
+		return $this->filterLocale($this->decoratedFactory->getUserLanguage($user));
 	}
 
 }

--- a/tests/unit/L10N/DecoratorTest.php
+++ b/tests/unit/L10N/DecoratorTest.php
@@ -93,6 +93,13 @@ class DecoratorTest extends TestCase {
 		foreach ($this->languages as $lang) {
 			$overrides = $this->nmcFactory->getOverrides($lang);
 			foreach ($overrides as $app => $apptranslations) {
+				if (!$this->nmcFactory->languageExists($app, $lang)) {
+					// overrides only apply if original apps have translations
+					// overrides should not replace original translations
+					$this->markTestIncomplete("Translation({$lang},{$app}) overrides, but has no base translations!");
+					continue;
+				}
+
 				$l = $this->nmcFactory->get($app, $lang);
 				foreach ($apptranslations as $key => $translation) {
 					if (\is_array($translation)) {

--- a/tests/unit/L10N/FactorySupportedLangTest.php
+++ b/tests/unit/L10N/FactorySupportedLangTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2016 Joas Schilling <nickvergessen@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ *
+ * All tests from server are copies and repeated to make sure that the
+ * decoration works properly.
+ *
+ * TODO: Find a way to inherit the tests from server instead of copying it
+ */
+
+namespace OCA\NMCTheme\Tests\L10N;
+
+use OC\L10N\Factory;
+use OCP\IL10N;
+
+class FactorySupportedLangTest extends FactoryTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config
+			->expects(self::any())
+			->method('getSystemValue')
+			->willReturnMap([
+				['nmc_supported_locales', false, ['de', 'de_DE', 'en_GB',   // suppored
+					'es', 'es_MX',          // supported not themed
+					'de_AT', 'co', 'co_XX' ]], // not supported
+			]);
+
+		$this->factory = $this->getFactory();
+		//$this->factory->getDecorated()->expects(self::once())
+		//	->method('findL10nDir')
+		//	->with($app)
+		//	->willReturn(\OC::$SERVERROOT . '//l10n/');
+	}
+
+	public function dataForTranslationsForAppTest() {
+		return [
+			['core', 'fr', false],
+			['lib', 'fr', false],
+			['files', 'fr', false],
+			['nmctheme', 'fr', false],
+			['end_to_end_encryption', 'fr', false],
+			['_unknown_app_', 'fr', false],
+			['core', 'en', true],
+			// server translation file non existing on V25
+			['lib', 'en', false],
+			['files', 'en', true],
+			['nmctheme', 'en', true],
+			['end_to_end_encryption', 'en', true],
+			// does not exist V25
+			['_unknown_app_', 'en', false],
+			['core', 'de', true],
+			['lib', 'de', true],
+			['files', 'de', true],
+			['nmctheme', 'de', true],
+			['end_to_end_encryption', 'de', true],
+			['_unknown_app_', 'de', true],
+			['core', 'de_DE', true],
+			['lib', 'de_DE', true],
+			['files', 'de_DE', true],
+			['nmctheme', 'de_DE', true],
+			['end_to_end_encryption', 'de_DE', true],
+			// core is always torn in
+			['_unknown_app_', 'de_DE', true],
+			['core', 'es', true],
+			['lib', 'es', true],
+			['files', 'es', true],
+			['nmctheme', 'es', false],
+			['end_to_end_encryption', 'es', true],
+			// core is always torn in
+			['_unknown_app_', 'es', true],
+			['core', 'es_MX', true],
+			['lib', 'es_MX', true],
+			['files', 'es_MX', true],
+			['nmctheme', 'es_MX', false],
+			['end_to_end_encryption', 'es_MX', true],
+			// core is always torn in as default
+			['_unknown_app_', 'es_MX', true],
+			['core', 'de_AT', false],
+			['lib', 'de_AT', false],
+			['files', 'de_AT', false],
+			['nmctheme', 'de_AT', false],
+			['end_to_end_encryption', 'de_AT', false],
+			['_unknown_app_', 'de_AT', false],
+			['core', 'co', false],
+			['lib', 'co', false],
+			['files', 'co', false],
+			['nmctheme', 'co', false],
+			['end_to_end_encryption', 'co', false],
+			['_unknown_app_', 'co', false]
+		];
+	}
+
+	/**
+	 * @dataProvider dataForTranslationsForAppTest
+	 */
+	public function testTranslationsForApp(string $app, string $lang, bool $hasValues) {
+		if ($hasValues) {
+			$this->assertNotEmpty($this->factory->getTranslationsForApp($app, $lang));
+		} else {
+			$this->assertEmpty($this->factory->getTranslationsForApp($app, $lang));
+		}
+	}
+
+	public function dataForGetL10N() {
+		return [
+			['core', 'fr', null, 'en', 'en'],
+			['lib', 'fr', null, 'en', 'en'],
+			['files', 'fr', null, 'en', 'en'],
+			['nmctheme', 'fr', null, 'en', 'en'],
+			['_unknown_app_', 'fr', null, 'en', 'en'],
+			['core', 'fr', 'fr_BE', 'en', 'en'],
+			['lib', 'fr', 'fr_BE', 'en', 'en'],
+			['files', 'fr', 'fr_BE', 'en', 'en'],
+			['nmctheme', 'fr', 'fr_BE', 'en', 'en'],
+			['_unknown_app_', 'fr', 'fr_BE', 'en', 'en'],
+			['core', 'en', null, 'en', 'en'],
+			['lib', 'en', null, 'en', 'en'],
+			['files', 'en', null, 'en', 'en'],
+			['nmctheme', 'en', null, 'en', 'en'],
+			['_unknown_app_', 'en', null, 'en', 'en'],
+			['core', 'en', 'en_US', 'en', 'en'],
+			['lib', 'en', 'en_US', 'en', 'en'],
+			['files', 'en', 'en_US', 'en', 'en'],
+			['nmctheme', 'en', 'en_US', 'en', 'en'],
+			['_unknown_app_', 'en', 'en_US', 'en', 'en'],
+			['core', 'en', 'en_GB', 'en', 'en_GB'],
+			['lib', 'en', 'en_GB', 'en', 'en_GB'],
+			['files', 'en', 'en_GB', 'en', 'en_GB'],
+			['nmctheme', 'en', 'en_GB', 'en', 'en_GB'],
+			['_unknown_app_', 'en', 'en_GB', 'en', 'en_GB'],
+			['core', null, 'en_US', 'en', 'en'],
+			['lib', null, 'en_US', 'en', 'en'],
+			['files', null, 'en_US', 'en', 'en'],
+			['nmctheme', null, 'en_US', 'en', 'en'],
+			['_unknown_app_', null, 'en_US', 'en', 'en'],
+			['core', null, 'de_DE', 'en', 'de_DE'],
+			['lib', null, 'de_DE', 'en', 'de_DE'],
+			['files', null, 'de_DE', 'en', 'de_DE'],
+			['nmctheme', null, 'de_DE', 'en', 'de_DE'],
+			['_unknown_app_', null, 'de_DE', 'en', 'de_DE'],
+			['core', 'de', 'de_DE', 'de', 'de_DE'],
+			['lib', 'de', 'de_DE', 'de', 'de_DE'],
+			['files', 'de', 'de_DE', 'de', 'de_DE'],
+			['nmctheme', 'de', 'de_DE', 'de', 'de_DE'],
+			['_unknown_app_', 'de', 'de_DE', 'de', 'de_DE'],
+			['core', 'de', null, 'de', 'de'],
+			['lib', 'de', null, 'de', 'de'],
+			['files', 'de', null, 'de', 'de'],
+			['nmctheme', 'de', null, 'de', 'de'],
+			['_unknown_app_', 'de', null, 'de', 'de'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataForGetL10N
+	 */
+	public function testGetL10N(string $app, string|null $lang, string|null $locale,
+		string $expectedLang, string $expectedLocale) {
+		$l10n = $this->factory->get($app, $lang, $locale);
+		$this->assertInstanceOf(IL10N::class, $l10n);
+		$this->assertEquals($expectedLang, $l10n->getLanguageCode());
+		$this->assertEquals($expectedLocale, $l10n->getLocaleCode());
+	}
+
+	public function testFindAvailableLocales() {
+		$locales = $this->factory->findAvailableLocales();
+		$this->assertCount(7, $locales);
+
+		// TODO: more testing!
+	}
+
+
+}

--- a/tests/unit/L10N/FactoryTestCase.php
+++ b/tests/unit/L10N/FactoryTestCase.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\NMCTheme\Tests\L10N;
+
+use OC\L10N\Factory;
+use OCA\NMCTheme\L10N\FactoryDecorator;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FactoryTestCase extends TestCase {
+	/** @var IConfig|MockObject */
+	protected $config;
+
+	/** @var IRequest|MockObject */
+	protected $request;
+
+	/** @var IUserSession|MockObject */
+	protected $userSession;
+
+	/** @var ICacheFactory|MockObject */
+	protected $cacheFactory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->config
+			->expects(self::any())
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['installed', false, true],
+			]);
+	}
+
+	protected function setUser(string $id) {
+		$this->user = $this->createMock(IUser::class);
+		$this->userSession->expects(self::atLeastOnce())
+				->method('getUser')
+				->willReturn($this->user);
+		$echo = function ($value) { return $value; };
+		$this->config->expects(self::atLeastOnce())
+					->method('getUserValue')
+					->willReturnMap([
+						['User_de', 'core', 'lang', null, 'de'],
+						['User_jp', 'core', 'lang', null, 'jp'],
+						['User_en', 'core', 'lang', null, 'en'],
+						['User_cz', 'core', 'lang', null, 'cz'],
+						['User_fr', 'core', 'lang', null, 'fr'],
+						['User_nl', 'core', 'lang', null, 'nl'],
+						['User_null', 'core', 'lang', null, null],
+					]);
+		$this->user->expects(self::any())
+				->method('getUID')
+				->willReturn($id);
+		return $this->user;
+	}
+
+	protected function numberOfConstructParams($class_name) {
+		$class_reflection = new \ReflectionClass($class_name);
+		$constructor = $class_reflection->getConstructor();
+		if ($constructor === null) {
+			return 0;
+		} else {
+			return $constructor->getNumberOfParameters();
+		}
+	}
+	
+
+	/**
+	 * @param string[] $methods
+	 * @param bool $mockRequestGetHeaderMethod
+	 *
+	 * @return Factory|MockObject
+	 */
+	protected function getFactory(array $methods = [], $mockRequestGetHeaderMethod = false) : FactoryDecorator {
+		if ($mockRequestGetHeaderMethod) {
+			$this->request->expects(self::any())
+				->method('getHeader')
+				->willReturn('');
+		}
+
+		if (!empty($methods)) {
+			if ($this->numberOfConstructParams('OC\L10N\Factory') == 4) {
+				// V25 constructor
+				$decorated = $this->getMockBuilder(Factory::class)
+									->setConstructorArgs([
+										$this->config,
+										$this->request,
+										$this->userSession,
+										\OC::$SERVERROOT,
+									])
+									->setMethods($methods)
+									->getMock();
+
+			} else {
+				// post V25
+				$cacheFactory = $this->createMock(ICacheFactory::class);
+				$decorated = $this->getMockBuilder(Factory::class)
+				->setConstructorArgs([
+					$this->config,
+					$this->request,
+					$this->userSession,
+					$decorated,
+					\OC::$SERVERROOT,
+				])
+				->setMethods($methods)
+				->getMock();
+			}
+		} else {
+			if ($this->numberOfConstructParams('OC\L10N\Factory') == 4) {
+				// V25 constructor
+				$decorated = new Factory($this->config, $this->request, $this->userSession, \OC::$SERVERROOT);
+			} else {
+				// post V25
+				$cacheFactory = $this->createMock(ICacheFactory::class);
+				$decorated = new Factory($this->config, $this->request, $this->userSession, $this->cacheFactory, \OC::$SERVERROOT);
+			}
+	
+		}
+		
+		$this->factory = new FactoryDecorator($this->config, $decorated);
+		return $this->factory;
+	}
+
+	/**
+	 * Allows us to test private methods/properties
+	 *
+	 * @param $object
+	 * @param $methodName
+	 * @param array $parameters
+	 * @return mixed
+	 */
+	protected static function invokePrivate($object, $methodName, array $parameters = []) {
+		if (is_string($object)) {
+			$className = $object;
+		} else {
+			$className = get_class($object);
+		}
+		$reflection = new \ReflectionClass($className);
+
+		if ($reflection->hasMethod($methodName)) {
+			$method = $reflection->getMethod($methodName);
+
+			$method->setAccessible(true);
+
+			return $method->invokeArgs($object, $parameters);
+		} elseif ($reflection->hasProperty($methodName)) {
+			$property = $reflection->getProperty($methodName);
+
+			$property->setAccessible(true);
+
+			if (!empty($parameters)) {
+				if ($property->isStatic()) {
+					$property->setValue(null, array_pop($parameters));
+				} else {
+					$property->setValue($object, array_pop($parameters));
+				}
+			}
+
+			if (is_object($object)) {
+				return $property->getValue($object);
+			}
+
+			return $property->getValue();
+		}
+
+		return false;
+	}
+
+	protected function addRequestLocales(array $locales) {
+		$this->request->expects(self::any())
+			->method('getHeader')
+			->with('ACCEPT_LANGUAGE')
+			->willReturn(implode('; ', $locales));
+
+		
+	}
+}

--- a/tests/unit/L10N/L10nTest.php
+++ b/tests/unit/L10N/L10nTest.php
@@ -9,22 +9,16 @@
 namespace OCA\NMCTheme\Tests\L10N;
 
 use DateTime;
-use OC\L10N\Factory;
-use OCA\NMCTheme\L10N\FactoryDecorator;
 use OCA\NMCTheme\L10N\L10N;
 use OCP\App\IAppManager;
-use OCP\ICacheFactory;
-use OCP\IConfig;
-use OCP\IRequest;
-use OCP\IUserSession;
-use PHPUnit\Framework\TestCase;
+use Punic\Calendar;
 
 /**
  * Class L10nTest
  *
  * @package Test\L10N
  */
-class L10nTest extends TestCase {
+class L10nTest extends FactoryTestCase {
 	private IAppManager $appMgr;
 	private string $l10nPath;
 
@@ -36,7 +30,6 @@ class L10nTest extends TestCase {
 		$this->appMgr = $app->getContainer()->get(IAppManager::class);
 		$this->l10nPath = $this->appMgr->getAppPath("nmctheme") . '/tests/data/l10n/';
 		$this->tz = date_default_timezone_get();
-		;
 		date_default_timezone_set('Asia/Tokyo');
 	}
 
@@ -60,22 +53,6 @@ class L10nTest extends TestCase {
 		return $translations;
 	}
 
-	/**
-	 * @return Factory
-	 */
-	protected function getFactory() {
-		/** @var \OCP\IConfig $config */
-		$config = $this->createMock(IConfig::class);
-		//$config->setSystemValue('default_language', 'en');
-
-		/** @var \OCP\IRequest $request */
-		$request = $this->createMock(IRequest::class);
-		/** @var IUserSession $userSession */
-		$userSession = $this->createMock(IUserSession::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		return new FactoryDecorator($config,
-			new Factory($config, $request, $userSession, $cacheFactory, \OC::$SERVERROOT));
-	}
 
 	public function testSimpleTranslationWithTrailingColon(): void {
 		$fac = $this->getFactory();
@@ -154,47 +131,70 @@ class L10nTest extends TestCase {
 		$this->assertEquals($expected, $l->t($string, ['1', '2']));
 	}
 
+
 	public function localizationData() {
+		$formatDate = function ($value, $locale) {
+			return (string) Calendar::formatDate($value, 'long', $locale);
+		};
+	
+		$formatDatetime = function ($value, $locale) {
+			return (string) Calendar::formatDatetime($value, 'long', $locale);
+		};
+	
+		$formatTime = function ($value, $locale) {
+			return (string) Calendar::formatTime($value, 'long', $locale);
+		};
+	
 		return [
 			// timestamp as string
-			['February 14, 2009, 8:31:30 AM GMT+9', 'en', 'en_US', 'datetime', '1234567890'],
-			['14. Februar 2009, 08:31:30 GMT+9', 'de', 'de_DE', 'datetime', '1234567890'],
-			['February 14, 2009', 'en', 'en_US', 'date', '1234567890'],
-			['14. Februar 2009', 'de', 'de_DE', 'date', '1234567890'],
-			['8:31:30 AM GMT+9', 'en', 'en_US', 'time', '1234567890'],
-			['08:31:30 GMT+9', 'de', 'de_DE', 'time', '1234567890'],
+			[$formatDatetime, 'en', 'en_US', 'datetime', '1234567890'],
+			[$formatDatetime, 'de', 'de_DE', 'datetime', '1234567890'],
+			[$formatDate, 'en', 'en_US', 'date', '1234567890'],
+			[$formatDate, 'de', 'de_DE', 'date', '1234567890'],
+			[$formatTime, 'en', 'en_US', 'time', '1234567890'],
+			[$formatTime, 'de', 'de_DE', 'time', '1234567890'],
 
 			// timestamp as int
-			['February 14, 2009, 8:31:30 AM GMT+9', 'en', 'en_US', 'datetime', 1234567890],
-			['14. Februar 2009, 08:31:30 GMT+9', 'de', 'de_DE', 'datetime', 1234567890],
-			['February 14, 2009', 'en', 'en_US', 'date', 1234567890],
-			['14. Februar 2009', 'de', 'de_DE', 'date', 1234567890],
-			['8:31:30 AM GMT+9', 'en', 'en_US', 'time', 1234567890],
-			['08:31:30 GMT+9', 'de', 'de_DE', 'time', 1234567890],
+			[$formatDatetime, 'en', 'en_US', 'datetime', 1234567890],
+			[$formatDatetime, 'de', 'de_DE', 'datetime', 1234567890],
+			[$formatDate, 'en', 'en_US', 'date', 1234567890],
+			[$formatDate, 'de', 'de_DE', 'date', 1234567890],
+			[$formatTime, 'en', 'en_US', 'time', 1234567890],
+			[$formatTime, 'de', 'de_DE', 'time', 1234567890],
 
 			// DateTime object
-			['February 13, 2009, 11:31:30 PM GMT+0', 'en', 'en_US', 'datetime', new DateTime('@1234567890')],
-			['13. Februar 2009, 23:31:30 GMT+0', 'de', 'de_DE', 'datetime', new DateTime('@1234567890')],
-			['February 13, 2009', 'en', 'en_US', 'date', new DateTime('@1234567890')],
-			['13. Februar 2009', 'de', 'de_DE', 'date', new DateTime('@1234567890')],
-			['11:31:30 PM GMT+0', 'en', 'en_US', 'time', new DateTime('@1234567890')],
-			['23:31:30 GMT+0', 'de', 'de_DE', 'time', new DateTime('@1234567890')],
+			[$formatDatetime, 'en', 'en_US', 'datetime', new DateTime('@1234567890')],
+			[$formatDatetime, 'de', 'de_DE', 'datetime', new DateTime('@1234567890')],
+			[$formatDate, 'en', 'en_US', 'date', new DateTime('@1234567890')],
+			[$formatDate, 'de', 'de_DE', 'date', new DateTime('@1234567890')],
+			[$formatTime, 'en', 'en_US', 'time', new DateTime('@1234567890')],
+			[$formatTime, 'de', 'de_DE', 'time', new DateTime('@1234567890')],
 
 			// en_GB
-			['13 February 2009, 23:31:30 GMT+0', 'en_GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
-			['13 February 2009', 'en_GB', 'en_GB', 'date', new DateTime('@1234567890')],
-			['23:31:30 GMT+0', 'en_GB', 'en_GB', 'time', new DateTime('@1234567890')],
-			['13 February 2009, 23:31:30 GMT+0', 'en-GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
-			['13 February 2009', 'en-GB', 'en_GB', 'date', new DateTime('@1234567890')],
-			['23:31:30 GMT+0', 'en-GB', 'en_GB', 'time', new DateTime('@1234567890')],
+			[$formatDatetime, 'en_GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
+			[$formatDatetime, 'en-GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
+			[$formatDate, 'en_GB', 'en_GB', 'date', new DateTime('@1234567890')],
+			[$formatDate, 'en-GB', 'en_GB', 'date', new DateTime('@1234567890')],
+			[$formatTime, 'en_GB', 'en_GB', 'time', new DateTime('@1234567890')],
+			[$formatTime, 'en-GB', 'en_GB', 'time', new DateTime('@1234567890')],
 		];
 	}
 
 	/**
 	 * @dataProvider localizationData
 	 */
-	public function testNumericStringLocalization($expectedDate, $lang, $locale, $type, $value) {
+	public function testNumericStringLocalization(callable $expectedFunc, $lang, $locale, $type, $data) {
 		$l = new L10N($this->getFactory(), 'test', $lang, $locale, []);
+		if ($data instanceof \DateTime) {
+			$value = $data;
+		} elseif (\is_string($data) && !is_numeric($data)) {
+			$value = new \DateTime();
+			$value->setTimestamp(strtotime($data));
+		} elseif ($data !== null) {
+			$value = new \DateTime();
+			$value->setTimestamp((int)$data);
+		}
+		$expectedDate = call_user_func($expectedFunc, $value, $locale);
 		$this->assertSame($expectedDate, $l->l($type, $value));
 	}
 


### PR DESCRIPTION
The PR restricts the supported languages to those locales set  in the system variable `nmc_supported_locales`(see README)

This not only limits the number of entries in the user settings, but also prohibits request languages to enforce
languages supported by Nextcloud but NOT by MagentaCLOUD.