### PR TITLE
Display settings -> Show hidden files/Crop image previews work only after refresh

### DIFF
--- a/css/apps/apps.scss
+++ b/css/apps/apps.scss
@@ -16,7 +16,7 @@
 }
 
 /* CONTENT  --------------------------------------------------------- */
-#content {
+#content, #content-vue {
   border-radius: 0;
 	margin: 76px 16px 0;
 	height: var(--body-height);

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -32,6 +32,7 @@
 			.icon.icon-add {
 				@include magenta-icon;
 				background-size: 16px 16px;
+				opacity: 1;
 			}
 		}
 

--- a/src/components/filesSettings.utils.ts
+++ b/src/components/filesSettings.utils.ts
@@ -4,6 +4,16 @@ import axios from '@nextcloud/axios'
 
 export const IS_LEGACY_VERSION = window._oc_config.version.startsWith('25')
 
+const SETTINGS_MAPPING = {
+	show_hidden: 'show',
+	crop_image_previews: 'crop',
+}
+
+const CONFIG_SETTINGS_MAPPING = {
+	show_hidden: 'showhidden',
+	crop_image_previews: 'cropimagepreviews',
+}
+
 export const loadStats = async () => {
 	let browserState = loadState('files', 'storageStats', null)
 	// v25
@@ -23,13 +33,10 @@ export const updateDisplaySettings = async (key: string, value: boolean) => {
 	try {
 		// v25
 		if (IS_LEGACY_VERSION) {
-			const keyName = {
-				show_hidden: 'show',
-				crop_image_previews: 'crop',
-			}
 			await axios.post(generateUrl('/apps/files/api/v1/' + key.replaceAll('_', '')), {
-				[keyName[key]]: value,
+				[SETTINGS_MAPPING[key]]: value,
 			})
+			window.OCA.Files.App._filesConfig.set(CONFIG_SETTINGS_MAPPING[key], value)
 			return
 		}
 		// v26, v27

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@ declare global {
     interface Window {
         _oc_theme_l10n_overrides?: ThemeTranslations
         _oc_config: { version: string } & Record<string, any>
-        OCA: { Theming: {cacheBuster: string }, Viewer: any }
+        OCA: { Theming: {cacheBuster: string }, Viewer: any, Files: any }
         OC: { requestToken: string}
     }
 }


### PR DESCRIPTION
Display settings changes were not reflected on a page in v25. This PR fixes this by additionaly updating global filesConfig object.