### PR TITLE
+Button > Remove the item 'set up templates folder'

### DIFF
--- a/src/js/newfilemenuplugin.js
+++ b/src/js/newfilemenuplugin.js
@@ -1,5 +1,4 @@
-(function() {
-
+window.addEventListener('DOMContentLoaded', function() {
 	const NewFileMenuPlugin = {
 
 		attach(menu) {
@@ -39,8 +38,11 @@
 					})
 				})
 			}
+
+			// remove 'Set up templates folder' option
+			menu.removeMenuEntry('template-init')
 		},
 	}
 
 	OC.Plugins.register('OCA.Files.NewFileMenu', NewFileMenuPlugin)
-})()
+})


### PR DESCRIPTION
This PR removes the 'Set up templates folder' option from the plus button in the breadcrumb