### PR TITLE
fixed filtering of available languages

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -128,10 +128,9 @@
     "Data protection": "Datenschutz",
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
-    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}% belegt",
+    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}&#x25; belegt",
     "of": "von",
     "used": "genutzt",
-    "Display settings": "Anzeigeeinstellungen",
-    "PhotosMedia": "Medien"
+    "Display settings": "Anzeigeeinstellungen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -128,10 +128,9 @@
     "Data protection": "Datenschutz",
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
-    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}% belegt",
+    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}&#x25; belegt",
     "of": "von",
     "used": "genutzt",
-    "Display settings": "Anzeigeeinstellungen",
-    "PhotosMedia": "Medien"
+    "Display settings": "Anzeigeeinstellungen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -128,10 +128,9 @@
         "Data protection": "Data protection",
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
-        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%",
+        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}&#x25;",
         "of": "of",
         "used": "used",
-        "Display settings": "Display settings",
-        "PhotosMedia": "Media"
+        "Display settings": "Display settings"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -128,10 +128,9 @@
         "Data protection": "Data protection",
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
-        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%",
+        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}&#x25;",
         "of": "of",
         "used": "used",
-        "Display settings": "Display settings",
-        "PhotosMedia": "Media"
+        "Display settings": "Display settings"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -135,16 +135,12 @@ class FactoryDecorator implements IFactory {
 			return $locales;
 		}
 
-		$filteredLocales = array_filter($locales, function ($locale) {
-			return in_array($locale['code'], $this->supported_locales);
-		});
-		
-		if (empty($this->supported_locales) ||
-			empty($filteredLocales)) {
+		$filteredLocales = array_intersect($locales, $this->supported_locales);
+		if (empty($filteredLocales)) {
 			return ['en'];
 		} else {
 			// make sure that indexed are corrected
-			return array_values($filteredLocales);
+			return array_unique(array_values($filteredLocales));
 		}
 	}
 
@@ -165,7 +161,7 @@ class FactoryDecorator implements IFactory {
 			return ['en'];
 		} else {
 			// make sure that indexed are corrected
-			return array_values($filteredLanguages);
+			return array_unique(array_values($filteredLanguages));
 		}
 	}
 
@@ -347,7 +343,9 @@ class FactoryDecorator implements IFactory {
 	 * @see private\L10N\Factory
 	 */
 	public function findAvailableLocales() {
-		return $this->filterLocales($this->decoratedFactory->findAvailableLocales());
+		return array_filter($this->decoratedFactory->findAvailableLocales(), function ($lang) {
+			return in_array($lang['code'], $this->supported_locales);
+		});
 	}
 
 	/**

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -135,7 +135,6 @@ class FactoryDecorator implements IFactory {
 			return $locales;
 		}
 
-
 		$filteredLocales = array_filter($locales, function ($locale) {
 			return in_array($locale['code'], $this->supported_locales);
 		});
@@ -146,6 +145,27 @@ class FactoryDecorator implements IFactory {
 		} else {
 			// make sure that indexed are corrected
 			return array_values($filteredLocales);
+		}
+	}
+
+	/**
+	 * Filter a set of supported languages (locales) (if set)
+	 */
+	protected function filterLanguages(array $languages) {
+		if (empty($this->supported_locales)) {
+			return $languages;
+		}
+
+		$filteredLanguages = array_filter($languages, function ($language) {
+			return in_array($language, $this->supported_locales);
+		});
+		
+		if (empty($this->supported_locales) ||
+			empty($filteredLanguages)) {
+			return ['en'];
+		} else {
+			// make sure that indexed are corrected
+			return array_values($filteredLanguages);
 		}
 	}
 
@@ -313,12 +333,12 @@ class FactoryDecorator implements IFactory {
 	}
 
 	/**
-	 * decorate standard IFactory with supported locale filter
+	 * decorate standard IFactory with supported languages (locales) filter
 	 * @see public\L10N\IFactory
 	 * @see private\L10N\Factory
 	 */
 	public function findAvailableLanguages($app = null): array {
-		return $this->filterLocales($this->decoratedFactory->findAvailableLanguages($app));
+		return $this->filterLanguages($this->decoratedFactory->findAvailableLanguages($app));
 	}
 
 	/**

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -145,27 +145,6 @@ class FactoryDecorator implements IFactory {
 	}
 
 	/**
-	 * Filter a set of supported languages (locales) (if set)
-	 */
-	protected function filterLanguages(array $languages) {
-		if (empty($this->supported_locales)) {
-			return $languages;
-		}
-
-		$filteredLanguages = array_filter($languages, function ($language) {
-			return in_array($language, $this->supported_locales);
-		});
-		
-		if (empty($this->supported_locales) ||
-			empty($filteredLanguages)) {
-			return ['en'];
-		} else {
-			// make sure that indexed are corrected
-			return array_unique(array_values($filteredLanguages));
-		}
-	}
-
-	/**
 	 * Predicate to check filter
 	 */
 	protected function isSupportedLocale(string $locale) {
@@ -334,7 +313,7 @@ class FactoryDecorator implements IFactory {
 	 * @see private\L10N\Factory
 	 */
 	public function findAvailableLanguages($app = null): array {
-		return $this->filterLanguages($this->decoratedFactory->findAvailableLanguages($app));
+		return $this->filterLocales($this->decoratedFactory->findAvailableLanguages($app));
 	}
 
 	/**

--- a/tests/unit/L10N/FactorySupportedLangTest.php
+++ b/tests/unit/L10N/FactorySupportedLangTest.php
@@ -24,10 +24,13 @@ class FactorySupportedLangTest extends FactoryTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+
+
 		$this->config
 			->expects(self::any())
 			->method('getSystemValue')
 			->willReturnMap([
+				['installed', false, true],
 				['nmc_supported_locales', false, ['de', 'de_DE', 'en_GB',   // suppored
 					'es', 'es_MX',          // supported not themed
 					'de_AT', 'co', 'co_XX' ]], // not supported
@@ -170,6 +173,7 @@ class FactorySupportedLangTest extends FactoryTestCase {
 		$this->assertEquals($expectedLocale, $l10n->getLocaleCode());
 	}
 
+
 	public function testFindAvailableLocales() {
 		$locales = $this->factory->findAvailableLocales();
 		$this->assertCount(7, $locales);
@@ -177,5 +181,33 @@ class FactorySupportedLangTest extends FactoryTestCase {
 		// TODO: more testing!
 	}
 
+	public function testFindAvailableLanguages() {
+		$languages = $this->factory->findAvailableLanguages();
+		$this->assertCount(6, $languages);
+		$languages = $this->factory->findAvailableLanguages('nmctheme');
+		$this->assertCount(4, $languages);
+
+		// TODO: more testing!
+	}
+
+	public function dataForFindLanguage() {
+		return [
+			['User_jp', 'en', 'en', 'en'],
+			['User_null', 'en', 'en', 'en'],
+			['User_de', 'de', 'de', 'de'],
+			['User_es', 'es', 'en', 'es']
+		];
+	}
+
+	/**
+	 * @dataProvider dataForFindLanguage
+	 */
+	public function testFindLanguage(string $username, string $expectedCore,
+		string $expectedTheme, string $expectedUnknown) {
+		$this->setUser($username);
+		self::assertSame($expectedCore, $this->factory->findLanguage('core'));
+		self::assertSame($expectedTheme, $this->factory->findLanguage('nmctheme'));
+		self::assertSame($expectedUnknown, $this->factory->findLanguage('_unknown_'));
+	}
 
 }

--- a/tests/unit/L10N/FactoryTestCase.php
+++ b/tests/unit/L10N/FactoryTestCase.php
@@ -58,6 +58,7 @@ class FactoryTestCase extends TestCase {
 						['User_cz', 'core', 'lang', null, 'cz'],
 						['User_fr', 'core', 'lang', null, 'fr'],
 						['User_nl', 'core', 'lang', null, 'nl'],
+						['User_es', 'core', 'lang', null, 'es'],
 						['User_null', 'core', 'lang', null, null],
 					]);
 		$this->user->expects(self::any())


### PR DESCRIPTION
The method findAvailableLanguages returns an array in the following format: ['en','de','etc'].

Therefore the function 
    in_array($locale['code'], $this->supported_locales) 
fails because of the undefined array key 'code'