### PR TITLE
Display settings -> 'Show folder info text' option

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -131,6 +131,7 @@
     "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}&#x25; belegt",
     "of": "von",
     "used": "genutzt",
-    "Display settings": "Anzeigeeinstellungen"
+    "Display settings": "Anzeigeeinstellungen",
+    "Show folder info text": "Ordnerinfotext anzeigen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -131,6 +131,7 @@
     "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}&#x25; belegt",
     "of": "von",
     "used": "genutzt",
-    "Display settings": "Anzeigeeinstellungen"
+    "Display settings": "Anzeigeeinstellungen",
+    "Show folder info text": "Ordnerinfotext anzeigen"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -131,6 +131,7 @@
         "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}&#x25;",
         "of": "of",
         "used": "used",
-        "Display settings": "Display settings"
+        "Display settings": "Display settings",
+        "Show folder info text": "Show folder info text"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -131,6 +131,7 @@
         "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}&#x25;",
         "of": "of",
         "used": "used",
-        "Display settings": "Display settings"
+        "Display settings": "Display settings",
+        "Show folder info text": "Show folder info text"
     },"pluralForm" :"nplurals=2; plural=(n != 1);"}
 }

--- a/src/components/DisplaySettings.vue
+++ b/src/components/DisplaySettings.vue
@@ -8,6 +8,11 @@
 			{{ t('nmctheme', 'Display settings') }}
 		</button>
 		<div class="display-settings__list" :class="{open: isOpened}">
+			<NcCheckboxRadioSwitch v-if="textAvailable"
+				:checked="userConfig.show_folder_info"
+				@update:checked="setConfig('show_folder_info', $event)">
+				{{ t('nmctheme', 'Show folder info text') }}
+			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch :checked="userConfig.show_hidden"
 				@update:checked="setConfig('show_hidden', $event)">
 				{{ t('files', 'Show hidden files') }}
@@ -23,6 +28,7 @@
 <script>
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import { useUserConfigStore } from '../store/userconfig.ts'
+import { loadState } from '@nextcloud/initial-state'
 import { translate } from '@nextcloud/l10n'
 
 export default {
@@ -42,7 +48,10 @@ export default {
 	},
 	computed: {
 		userConfig() {
-			return this.userConfigStore.userConfig
+			return this.userConfigStore
+		},
+		textAvailable() {
+			return loadState('text', 'workspace_available', false)
 		},
 	},
 	methods: {

--- a/src/components/filesSettings.utils.ts
+++ b/src/components/filesSettings.utils.ts
@@ -1,5 +1,6 @@
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
+import { emit } from '@nextcloud/event-bus'
 import axios from '@nextcloud/axios'
 
 export const IS_LEGACY_VERSION = window._oc_config.version.startsWith('25')
@@ -31,17 +32,23 @@ export const loadStats = async () => {
 
 export const updateDisplaySettings = async (key: string, value: boolean) => {
 	try {
+		if (key === 'show_folder_info') {
+			await axios.post(generateUrl('/apps/text/settings'), {
+				key: 'workspace_enabled', value: value ? '1' : '0',
+			}).then(() => emit(value ? 'Text::showRichWorkspace' : 'Text::hideRichWorkspace', { autofocus: true }))
+			return
+		}
 		// v25
 		if (IS_LEGACY_VERSION) {
 			await axios.post(generateUrl('/apps/files/api/v1/' + key.replaceAll('_', '')), {
 				[SETTINGS_MAPPING[key]]: value,
 			})
 			window.OCA.Files.App._filesConfig.set(CONFIG_SETTINGS_MAPPING[key], value)
-			return
+		} else {
+			// v26, v27
+			await axios.put(generateUrl('/apps/files/api/v1/config/' + key), {
+				value,
+			})
 		}
-		// v26, v27
-		await axios.put(generateUrl('/apps/files/api/v1/config/' + key), {
-			value,
-		})
 	} catch (error) { }
 }


### PR DESCRIPTION
This PR adds an option to the display settings menu that allows the user to control text workspace visibility