### PR TITLE
Old artefacts due to lazy load sequence

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -128,7 +128,7 @@
     "Data protection": "Datenschutz",
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
-    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}&#x25; belegt",
+    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}% belegt",
     "of": "von",
     "used": "genutzt",
     "Display settings": "Anzeigeeinstellungen",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -128,7 +128,7 @@
     "Data protection": "Datenschutz",
     "Faq": "Hilfe & FAQ",
     "Expand storage": "Speicher erweitern",
-    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}&#x25; belegt",
+    "Memory used up to {memoryUsage}%": "Speicher zu {memoryUsage}% belegt",
     "of": "von",
     "used": "genutzt",
     "Display settings": "Anzeigeeinstellungen",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -128,7 +128,7 @@
         "Data protection": "Data protection",
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
-        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}&#x25;",
+        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%",
         "of": "of",
         "used": "used",
         "Display settings": "Display settings",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -128,7 +128,7 @@
         "Data protection": "Data protection",
         "Faq": "Help & FAQ",
         "Expand storage": "Expand storage",
-        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}&#x25;",
+        "Memory used up to {memoryUsage}%": "Memory used up to {memoryUsage}%",
         "of": "of",
         "used": "used",
         "Display settings": "Display settings",

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -92,12 +92,12 @@ class BeforeTemplateRenderedListener implements IEventListener {
 
 		// you can add additional styles, links and scripts before rendering
 		// keep src for future use:   \OCP\Util::addScript("nmctheme", "../dist/l10nappender");
+		\OCP\Util::addScript("nmctheme", "nmctheme-nmclogo", "core");
+		\OCP\Util::addScript('nmctheme', 'nmctheme-nmcfooter', "core");
 		\OCP\Util::addScript("nmctheme", "nmctheme-mimetypes", "core");
-		\OCP\Util::addScript('nmctheme', 'nmctheme-nmcfooter', 'theming');
 		\OCP\Util::addScript("nmctheme", "nmctheme-newfilemenuplugin", "files");
 		\OCP\Util::addScript("nmctheme", "nmctheme-filelistplugin", "files");
 		\OCP\Util::addScript("nmctheme", "nmctheme-filessettings", "files");
-		\OCP\Util::addScript("nmctheme", "nmctheme-nmclogo");
 		\OCP\Util::addScript("nmctheme", "nmctheme-conflictdialog");
 	}
 }


### PR DESCRIPTION
We are loading header and footer relatively late, so that old Nextcloud fragments are shown - esp. on the login page.
Prioritized  header/footer to reloaded shortly after core.

Additionally, the entity patch for the percentage symbol in translations is taken back, breaking the unittests but fixing the visual problem. Entities seem not to be handled properly in Chrome.
