### PR TITLE
Nmc/2554 header user menu customization

### DIFF
--- a/css/apps/settings.scss
+++ b/css/apps/settings.scss
@@ -184,6 +184,7 @@ $breakpoint-mobile-small: 480px;
 
 				&:hover, &:focus {
 					border: none;
+					outline: none;
 				}
 
 				.button-vue__icon {
@@ -227,9 +228,15 @@ $breakpoint-mobile-small: 480px;
 				line-height: 3rem;
 				padding: 0;
 
+				&:focus {
+					outline: none;
+				}
+
 				.plus-icon {
 					border: 1px solid var(--telekom-color-primary-standard);
 					border-radius: 1rem;
+					height: 1.5rem;
+					width: 1.5rem;
 				}
 			}
 		}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -13,7 +13,6 @@ use OC\AppFramework\DependencyInjection\DIContainer;
 
 use OC\L10N\Factory;
 use OC\NavigationManager;
-use OC\Settings\Manager as SettingsManager;
 use OC\Template\JSCombiner;
 use OC\Template\JSResourceLocator;
 use OC\URLGenerator;
@@ -22,7 +21,6 @@ use OCA\NMCTheme\L10N\FactoryDecorator;
 use OCA\NMCTheme\Listener\BeforeTemplateRenderedListener;
 use OCA\NMCTheme\NavigationManagerDecorator;
 use OCA\NMCTheme\Service\NMCThemesService;
-use OCA\NMCTheme\SettingsManagerDecorator;
 use OCA\NMCTheme\Themes\Magenta;
 use OCA\NMCTheme\Themes\MagentaDark;
 use OCA\NMCTheme\Themes\TeleNeoWebFont;
@@ -42,7 +40,6 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\QueryException;
 use OCP\Files\IMimeTypeDetector;
-use OCP\Settings\IManager as ISettingsManager;
 
 // FIXME: required private accesses; we have to find better ways
 // when integrating upstream

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,13 +12,17 @@ namespace OCA\NMCTheme\AppInfo;
 use OC\AppFramework\DependencyInjection\DIContainer;
 
 use OC\L10N\Factory;
+use OC\NavigationManager;
+use OC\Settings\Manager as SettingsManager;
 use OC\Template\JSCombiner;
 use OC\Template\JSResourceLocator;
 use OC\URLGenerator;
 use OCA\NMCTheme\JSResourceLocatorExtension;
 use OCA\NMCTheme\L10N\FactoryDecorator;
 use OCA\NMCTheme\Listener\BeforeTemplateRenderedListener;
+use OCA\NMCTheme\NavigationManagerDecorator;
 use OCA\NMCTheme\Service\NMCThemesService;
+use OCA\NMCTheme\SettingsManagerDecorator;
 use OCA\NMCTheme\Themes\Magenta;
 use OCA\NMCTheme\Themes\MagentaDark;
 use OCA\NMCTheme\Themes\TeleNeoWebFont;
@@ -38,10 +42,12 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\QueryException;
 use OCP\Files\IMimeTypeDetector;
+use OCP\Settings\IManager as ISettingsManager;
 
 // FIXME: required private accesses; we have to find better ways
 // when integrating upstream
 use OCP\IConfig;
+use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
@@ -119,6 +125,19 @@ class Application extends App implements IBootstrap {
 
 
 	/**
+	 * Decorate the INavigationManager.
+	 */
+	protected function registerNavigationManagerDecorator(IRegistrationContext $context) {
+		$this->getContainer()->getServer()->registerService(INavigationManager::class, function (ContainerInterface $c) {
+			return new NavigationManagerDecorator(
+				$c->get(IConfig::class),
+				$this->getContainer()->getServer()->query(NavigationManager::class),
+			);
+		});
+	}
+
+
+	/**
 	 * Decorate the L10N IFactory of server with the L10N theming factory
 	 * so that any request for translation is either overridden by a value
 	 * from this app or delegated to the original factory
@@ -133,8 +152,6 @@ class Application extends App implements IBootstrap {
 		$context->registerServiceAlias(Factory::class, IFactory::class);
 		$context->registerServiceAlias(FactoryDecorator::class, IFactory::class);
 	}
-
-
 
 	/**
 	 * Register all kind of decorators so that the theme is in control
@@ -173,12 +190,14 @@ class Application extends App implements IBootstrap {
 		// intercept requests for favicons to enforce own behavior
 		$this->registerURLGeneratorDecorator($context);
 
+		// intercept requests for main navigation elements
+		$this->registerNavigationManagerDecorator($context);
+
 		// intercept requests for translations, theme specific translations have prio
 		$this->registerIFactoryDecorator($context);
 
 		// load mimetype customisations from within the theme to keep all customisations in one place
 		$this->registerMimeTypeCustomisations($context);
-
 
 		/**
 		 * Add listeners that can inject additional information or scripts before rendering

--- a/lib/L10N/FactoryDecorator.php
+++ b/lib/L10N/FactoryDecorator.php
@@ -43,8 +43,8 @@ class LanguageIteratorDecorator implements ILanguageIterator {
 		}
 	}
 
-	public function next(): bool {
-		return $this->decorated->next();
+	public function next(): void {
+		$this->decorated->next();
 	}
 
 	public function key(): int {

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -93,6 +93,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		// you can add additional styles, links and scripts before rendering
 		// keep src for future use:   \OCP\Util::addScript("nmctheme", "../dist/l10nappender");
 		\OCP\Util::addScript("nmctheme", "nmctheme-nmclogo", "core");
+		\OCP\Util::addScript('nmctheme', 'nmctheme-nmcheader', "core");
 		\OCP\Util::addScript('nmctheme', 'nmctheme-nmcfooter', "core");
 		\OCP\Util::addScript("nmctheme", "nmctheme-mimetypes", "core");
 		\OCP\Util::addScript("nmctheme", "nmctheme-newfilemenuplugin", "files");

--- a/lib/NavigationManagerDecorator.php
+++ b/lib/NavigationManagerDecorator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 T-Systems International
+ *
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\NMCTheme;
+
+use OCP\IConfig;
+use OCP\INavigationManager;
+
+class NavigationManagerDecorator implements INavigationManager {
+
+	protected IConfig $config;
+	protected INavigationManager $decorated;
+
+	public function __construct(IConfig $config, INavigationManager $decorated) {
+		$this->config = $config;
+		$this->decorated = $decorated;
+	}
+
+	/**
+	 * No decoration, only delegate.
+	 */
+	public function add($entry) {
+		return $this->decorated->add($entry);
+	}
+
+	/**
+	 * No decoration, only delegate.
+	 */
+	public function setActiveEntry($appId) {
+		return $this->decorated->setActiveEntry($appId);
+	}
+
+	/**
+	 * No decoration, only delegate.
+	 */
+	public function getActiveEntry() {
+		return $this->decorated->getActiveEntry();
+	}
+
+	/**
+	 * Deactivate use menu entries.
+	 */
+	public function getAll(string $type = self::TYPE_APPS): array {
+		if($type === 'settings') {
+			$deactivate = $this->config->getSystemValue('nmc_deactivate_user_menu_entry', false);
+			$all = $this->decorated->getAll($type);
+
+			foreach ($deactivate as $value) {
+				unset($all[$value]);
+			}
+
+			return $all;
+		}
+
+		return $this->decorated->getAll($type);
+	}
+
+	/**
+	 * No decoration, only delegate.
+	 */
+	public function setUnreadCounter(string $id, int $unreadCounter): void {
+		$this->decorated->setUnreadCounter($id, $unreadCounter);
+	}
+}

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,0 +1,33 @@
+<template>
+	<div>
+		<li v-for="item in items"
+			:id="item.id"
+			:key="item.id"
+			class="menu-entry">
+			<a :href="item.url" :target="item.target">
+				<span>{{ t('nmcsettings', item.name) }}</span>
+			</a>
+		</li>
+	</div>
+</template>
+
+<script>
+import { translate } from '@nextcloud/l10n'
+
+export default {
+	props: {
+		menuItems: {
+			type: Array,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			items: this.menuItems,
+		}
+	},
+	methods: {
+		t: translate,
+	},
+}
+</script>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ declare global {
         _oc_theme_l10n_overrides?: ThemeTranslations
         _oc_config: { version: string } & Record<string, any>
         OCA: { Theming: {cacheBuster: string }, Viewer: any, Files: any }
-        OC: { requestToken: string}
+        OC: { requestToken: string }
     }
 }
 

--- a/src/nmcheader.ts
+++ b/src/nmcheader.ts
@@ -26,7 +26,7 @@ window.addEventListener('DOMContentLoaded', function() {
 	const head = document.querySelector('head')
 	if (head !== null) {
 		const user = head.attributes['data-user-displayname'].value
-	
+
 		const menuButton = document.querySelector('#user-menu > a')
 		if (menuButton !== null) {
 			menuButton.innerHTML = '<span>' + user + '</span>'

--- a/src/nmcheader.ts
+++ b/src/nmcheader.ts
@@ -1,0 +1,51 @@
+import Vue from 'vue'
+import UserMenu from './components/UserMenu.vue'
+import { translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
+
+const app = 'nmctheme'
+
+const menuItems = [{
+	id: 'settings',
+	name: t(app, 'Account settings'),
+	url: generateUrl('/settings/user/account'),
+	target: '_self',
+}, {
+	id: 'help',
+	name: t(app, 'Faq'),
+	url: 'https://cloud.telekom-dienste.de/hilfe',
+	target: '_blank',
+}, {
+	id: 'customer_center',
+	name: t(app, 'Customer center'),
+	url: 'https://www.telekom.de/mein-kundencenter',
+	target: '_blank',
+}]
+
+window.addEventListener('DOMContentLoaded', function() {
+	const head = document.querySelector('head')
+	if (head !== null) {
+		const user = head.attributes['data-user-displayname'].value
+	
+		const menuButton = document.querySelector('#user-menu > a')
+		if (menuButton !== null) {
+			menuButton.innerHTML = '<span>' + user + '</span>'
+		}
+	}
+
+	const searchButton = document.querySelector('#unified-search > a')
+	if (searchButton !== null) {
+		searchButton.innerHTML = '<span>' + t(app, 'Search') + '</span>'
+	}
+
+	const menuElements = document.createElement('div')
+	menuElements.id = 'nmcsettings-menu'
+
+	const userMenu = document.querySelector('nav.user-menu__nav ul')
+	if (userMenu !== null) {
+		userMenu.prepend(menuElements)
+	}
+
+	const View = Vue.extend(UserMenu)
+	new View({ propsData: { menuItems } }).$mount('#nmcsettings-menu')
+})

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,0 +1,4 @@
+declare module "*.vue" {
+    import Vue from 'vue';
+    export default Vue;
+}

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,4 +1,4 @@
-declare module "*.vue" {
-    import Vue from 'vue';
-    export default Vue;
+declare module '*.vue' {
+    import Vue from 'vue'
+    export default Vue
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -12,6 +12,7 @@ webpackConfig.entry = {
 		conflictdialog: path.join(__dirname, 'src', 'js', 'conflictdialog.js'),
         mimetypes: path.join(__dirname, 'src', 'js', 'mimetypes.js'),
 		nmcfooter: path.join(__dirname, 'src', 'nmcfooter.ts'),
+		nmcheader: path.join(__dirname, 'src', 'nmcheader.ts'),
 		nmclogo: path.join(__dirname, 'src', 'nmclogo.ts')
 	}
 


### PR DESCRIPTION
Added a backend side navigation manager to the nmctheme app. 

In order to deactivate unwanted user menu items following has to be included in the config.php file:

  'nmc_deactivate_user_menu_entry' => 
  array (
    0 => 'user_status-menu-entry',
    1 => 'accessibility_settings',
    2 => 'settings',
    3 => 'help',
  ),

This should be considered the standard setting, but the array can be expanded or shortened as needed.
The values correspond to the ids assigned to the menu item. (And can be determined by examining the code of the list item)

Our own user menu elements are added in the nmcheader.ts file.