### PR TITLE
Upload bar - Set inner label color to white

### DIFF
--- a/css/components/upload.scss
+++ b/css/components/upload.scss
@@ -24,6 +24,10 @@
 		
 		.label {
 			font-size: 16px;
+			// inner label that appears once the progress bar reaches it
+			&.inner {
+				color: white;
+			}
 		}
 	}
 


### PR DESCRIPTION
Label text color turns white when progress bar is in the background ![Screenshot 2023-10-13 115935](https://github.com/nextmcloud/nmctheme/assets/139760733/59d8cbe8-e192-442c-9f2a-3d0287bb26a8)
