### PR TITLE
Blacklist for search providers

### DIFF
--- a/lib/Search/SearchComposerDecorator.php
+++ b/lib/Search/SearchComposerDecorator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 T-Systems International
+ *
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\NMCTheme\Search;
+
+use OC\Search\SearchComposer;
+use OCP\Search\SearchResult;
+use OCP\Search\ISearchQuery;
+
+use OCP\IUser;
+
+
+/**
+ * Blacklist unwanted search types like apps or settings for full-text search
+ * so that these types are not delivered to client at all - even when using
+ * API directly.
+ */
+class SearchComposerDecorator extends SearchComposer {
+    protected SearchComposer $decorated;
+    protected array $providerBlacklist = [];
+
+
+	public function __construct(SearchComposer $decorated,
+                                array $providerBlacklist ) {
+		$this->decorated = $decorated;
+		$this->providerBlacklist = $providerBlacklist;
+    }
+
+    /**
+     * Get providers with the blacklisted ones filtered out
+     */
+    public function getProviders(string $route, array $routeParameters): array {
+		$providers = $this->decorated->getProviders($route, $routeParameters);
+		return array_filter($providers, function($p) {
+            return !in_array($p['id'], $this->providerBlacklist);
+        });
+	}
+
+	/**
+	 * Query an individual search provider for results
+	 *
+	 * @param IUser $user
+	 * @param string $providerId one of the IDs received by `getProviders`
+	 * @param ISearchQuery $query
+	 *
+	 * @return SearchResult
+	 * @throws InvalidArgumentException when the $providerId does not correspond to a registered provider
+	 */
+	public function search(IUser $user,
+						   string $providerId,
+						   ISearchQuery $query): SearchResult {
+		
+        if (in_array($providerId, $this->providerBlacklist)) {
+            // for performance reasons, we do not use the correct app name for blacklisted searches
+            // anyway, this is only shown if somebody tries to mess around with search
+            return SearchResult::complete($providerId, []);
+        } else {
+            return $this->decorated->search($user, $providerId, $query);
+        }
+	}
+
+}

--- a/tests/unit/RegistrationsTest.php
+++ b/tests/unit/RegistrationsTest.php
@@ -22,6 +22,9 @@ use OCA\Theming\Service\ThemesService;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 
+use OCA\NMCTheme\Search\SearchComposerDecorator;
+use OC\Search\SearchComposer;
+
 use PHPUnit\Framework\TestCase;
 
 class RegistrationsTest extends TestCase {
@@ -47,4 +50,10 @@ class RegistrationsTest extends TestCase {
 		$factoryDecorator = $this->app->getContainer()->get(IFactory::class);
 		$this->assertInstanceOf(FactoryDecorator::class, $factoryDecorator, "FATAL: L10N FactoryDecorator failed to register!");
 	}
+
+    public function testDecoratedSearchComposer() :void {
+		$searchComposer = $this->app->getContainer()->get(SearchComposer::class);
+		$this->assertInstanceOf(SearchComposerDecorator::class, $searchComposer, "FATAL: SearchComposerDecorator (Search\\IProvider blacklister) failed to register!");
+	}
+
 }

--- a/tests/unit/Search/SearchComposerDecoratorTest.php
+++ b/tests/unit/Search/SearchComposerDecoratorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 T-Systems International
+ *
+ * @author B. Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Test blacklisting of search providers to avoid unwanted test results 
+ */
+namespace OCA\NMCTheme\Test\Search;
+
+use OCA\NMCTheme\Search\SearchComposerDecorator;
+use OCP\IServerContainer;
+use OC\Search\SearchComposer;
+use OCP\Search\SearchResult;
+use OCP\Search\ISearchQuery;
+use OC\AppFramework\Bootstrap\Coordinator;
+use Psr\Log\LoggerInterface;
+use OCP\IUser;
+
+use PHPUnit\Framework\TestCase;
+
+class SearchComposerDecoratorTest extends TestCase {
+	
+    protected function setUp(): void {
+        parent::setUp();
+
+        // test behavior in combination with the core apps
+        $this->app = new \OCP\AppFramework\App("nmctheme");
+    }
+
+    public function testGetProviders() {
+        $this->composerService = 
+            new SearchComposerDecorator(
+                new SearchComposer(
+                    $this->app->getContainer()->get(Coordinator::class),
+                    $this->app->getContainer()->get(IServerContainer::class),
+                    $this->app->getContainer()->get(LoggerInterface::class)
+                ),
+                ['contacts', // from apps/dav
+                 'calendar', 
+                 'tasks',
+                 'settings_apps', // from apps/settings 
+                 'settings',
+                 'systemtags' // from apps/systemtags (first candidate to enable in the future!)
+                ]
+            ); 
+        $providers=array_values($this->composerService->getProviders('/', []));
+        $providerIds=array_map(function($p) { return $p['id']; }, $providers);
+        $this->assertNotContains('contacts', $providerIds);
+        $this->assertNotContains('calender', $providerIds);
+        $this->assertNotContains('tasks', $providerIds);
+        $this->assertNotContains('settings_apps', $providerIds);
+        $this->assertNotContains('settings', $providerIds);
+        $this->assertNotContains('systemtags', $providerIds);
+        $this->assertContains('files', $providerIds);
+    }
+
+    protected function createSearchMock(){
+        $this->decorated = $this->createMock(SearchComposer::class);
+        $this->composerService = 
+            new SearchComposerDecorator(
+                $this->decorated,
+               ['contacts', // from apps/dav
+                'calendar', 
+                'tasks',
+                'settings_apps', // from apps/settings 
+                'settings',
+                'systemtags' // from apps/systemtags (first candidate to enable in the future!)
+                ]
+            ); 
+        $this->user=$this->createMock(IUser::class);
+        $this->query=$this->createMock(ISearchQuery::class);  
+    }
+
+    public function testSearchBlacklisted() {
+        $this->createSearchMock();
+        $this->decorated->expects(self::never())->method("search");
+        $result = $this->composerService->search($this->user, 'tasks', $this->query)->jsonSerialize();
+
+        $this->assertEquals('tasks', $result['name']);
+        $this->assertFalse($result['isPaginated']);
+        $this->assertEmpty($result['entries']);
+    }
+
+    public function testSearch() {
+        $this->createSearchMock();
+        $this->decorated->expects(self::once())
+            ->method("search")
+            ->with($this->equalTo($this->user), $this->equalTo('files'), $this->equalTo($this->query))
+            ->willReturn(SearchResult::complete('files', []));
+        $result = $this->composerService->search($this->user, 'files', $this->query)->jsonSerialize();
+
+        
+    }
+
+}


### PR DESCRIPTION
Nextcloud allows to search for tasks, calendar entries, settings .. by default.
Unsupported providers should be filtered, results of this type should not appear in search list.

The blacklist is hardcoded set during registration in `application.php`, there is no configuration setting for it yet.

 