### PR TITLE
Sidebar navigation - styling fixes

### DIFF
--- a/css/_mixins.scss
+++ b/css/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin color-icon {
-	filter: invert(14%) sepia(83%) saturate(3815%) hue-rotate(313deg) brightness(89%) contrast(127%);
+	filter: invert(17%) sepia(87%) saturate(5418%) hue-rotate(319deg) brightness(85%) contrast(110%);
 	@media (prefers-color-scheme: dark) {    
-		filter: brightness(0) saturate(100%) invert(14%) sepia(83%) saturate(3815%) hue-rotate(313deg) brightness(89%) contrast(127%);
+		filter: brightness(0) saturate(100%) invert(17%) sepia(87%) saturate(5418%) hue-rotate(319deg) brightness(85%) contrast(110%);
 	}
 }
 

--- a/css/components/ncappnavigation.scss
+++ b/css/components/ncappnavigation.scss
@@ -3,8 +3,6 @@
 $breakpoint-mobile: 1024px;
 
 :root {
-	--color-hover: var(--telekom-color-text-and-icon-primary-hovered);
-	--color-active: var(--telekom-color-text-and-icon-primary-pressed);
 	--internal-padding: 0;
 }
 
@@ -43,7 +41,7 @@ $breakpoint-mobile: 1024px;
 			padding: 0.25rem;
 		}
 		&:hover,  &.active {
-			background-color: var(--color-background-hover);
+			background-color: var(--nmc-color-background-hover);
 		}
 		// do not pin app navigation entries to the bottom
 		&--pinned {
@@ -62,7 +60,7 @@ $breakpoint-mobile: 1024px;
 			background-color: var(--telekom-color-primary-standard);
 		}
 		span {
-			color: var(--color-active);
+			color: var(--telekom-color-text-and-icon-primary-standard);
 		}
 		.app-navigation-entry-icon {
 			@include color-icon;
@@ -72,7 +70,7 @@ $breakpoint-mobile: 1024px;
 	// on hover link styling
 	.app-navigation-entry:hover {
 		span {
-			color: var(--color-hover);
+			color: var(--telekom-color-text-and-icon-primary-standard);
 		}
 		.app-navigation-entry-icon {
 			@include color-icon;
@@ -82,13 +80,6 @@ $breakpoint-mobile: 1024px;
 	// hide Collapse buttons
 	.app-navigation-entry--collapsible button.icon-collapse{
 		display: none;
-	}
-}
-
-@media (prefers-color-scheme: dark) {    
-	:root {
-		--color-hover: var(--telekom-color-text-and-icon-primary-pressed);
-		--color-active: var(--telekom-color-text-and-icon-primary-hovered);
 	}
 }
 

--- a/css/components/ncbuttons.scss
+++ b/css/components/ncbuttons.scss
@@ -22,6 +22,7 @@
     padding: 0;
     border-radius: var(--telekom-radius-standard);
     font: var(--telekom-text-style-body);
+    font-weight: var(--telekom-typography-font-weight-bold);
     line-height: 1.125rem;
     min-height: var(--telekom-spacing-composition-space-13);
     min-width: var(--telekom-spacing-composition-space-13);
@@ -95,7 +96,7 @@
 
         &:hover:not(:disabled) {
             color: var(--telekom-color-text-and-icon-standard);
-            background-color: var(--telekom-color-ui-state-fill-standard);
+            background-color: var(--nmc-color-background-hover);
             border-color: var(--telekom-color-ui-border-hovered);
         }
 

--- a/css/nmcdefault.scss
+++ b/css/nmcdefault.scss
@@ -97,4 +97,5 @@
   --color-background-plain: var(--telekom-color-background-canvas);
 
   --nmc-breakpoint-mobile: 1024px;
+  --nmc-color-background-hover: #EDEDED;
 }

--- a/css/v25/ncappnavigation.scss
+++ b/css/v25/ncappnavigation.scss
@@ -24,6 +24,11 @@ $breakpoint-mobile: 1024px;
 	}
 
 	& > ul > li {
+		// remove already hidden from DOM so they won't take up space
+		&.hidden-visually{
+			display: none;
+		}
+
 		font: var(--telekom-text-style-ui-bold);
 		margin-bottom: var(--telekom-spacing-composition-space-03);
 
@@ -51,8 +56,8 @@ $breakpoint-mobile: 1024px;
 		}
 
 		& > a:hover,  & > a.active, &.active > a {
-			color: var(--color-hover);
-			background-color: var(--color-background-hover);
+			color: var(--telekom-color-text-and-icon-primary-standard);
+			background-color: var(--nmc-color-background-hover);
 
 			&::after, img {
 				@include color-icon;

--- a/src/components/StorageQuota.vue
+++ b/src/components/StorageQuota.vue
@@ -9,7 +9,7 @@
 		<p v-if="memoryUsed > 0">
 			{{ t('nmctheme', 'Memory used up to {memoryUsage}%', { memoryUsage }) }}
 		</p>
-		<a class="storage-quota__link"
+		<a class="button-vue--vue-secondary storage-quota__link"
 			target="_blank"
 			rel="noopener"
 			href="https://cloud.telekom-dienste.de/tarife">
@@ -132,13 +132,8 @@ export default {
 	&__link {
 		width: fit-content;
 		padding: 0.5rem 1.5rem;
-		border-radius: var(--telekom-radius-small);
 		font: var(--telekom-text-style-body);
-		border: 1px solid #191919;
-		&:hover {
-			border-color: var(--telekom-color-primary-standard);
-			color: var(--telekom-color-primary-standard);
-		}
+		font-weight: bold;
 	}
 }
 </style>


### PR DESCRIPTION
Fixes for sidebar navigation
- introduce global variable for #EDEDED color
- correct font and background color on hover
- 'Expand storage' button is styled to secondary button of Scale
- equal gap between navigation items