### PR TITLE
My shares - fix icons not rendering if only one share exists

### DIFF
--- a/src/js/shareicons.js
+++ b/src/js/shareicons.js
@@ -38,7 +38,7 @@ const generateText = (recipients) => {
  */
 const generateShareList = (action, recipients, shareTypes) => {
 	action.empty()
-	shareTypes.split(',').forEach(shareType => {
+	String(shareTypes).split(',').forEach(shareType => {
 		const iconEl = document.createElement('span')
 		iconEl.className = 'icon'
 		if (parseInt(shareType) === ShareTypes.SHARE_TYPE_LINK) {


### PR DESCRIPTION
This pr fixes a bug where custom icons were not rendering if only one share exists for a file