### PR TITLE
Change background image for error page view

### DIFF
--- a/css/layouts/status.scss
+++ b/css/layouts/status.scss
@@ -14,7 +14,7 @@
     scrollbar-color: var(--telekom-color-primary-pressed) var(--telekom-color-text-and-icon-primary-standard);
 
     // this is the dedicated background image for login
-    background-image: url('../img/telekom/tectopview23.jpg');
+    background-image: url('../img/telekom/consent.svg');
     background-size: cover;
     background-position: center center;
     background-repeat: no-repeat;
@@ -43,6 +43,6 @@
     #body-status {
         background-image: linear-gradient(rgba(0, 0, 0, 0.5),
                 rgba(0, 0, 0, 0.5)),
-            url('../img/telekom/tectopview23.jpg');
+            url('../img/telekom/consent.svg');
     }
 }


### PR DESCRIPTION
https://jira.telekom.de/projects/NMC/issues/NMC-2609
As discussed on 19.10. in our review call, as the error page view is used in other scenarios as well, not only for file sharing expired link ("guest view"), only background image should be changed.