### PR TITLE
fixed delete file bug

### DIFF
--- a/src/js/filelistplugin.js
+++ b/src/js/filelistplugin.js
@@ -5,7 +5,6 @@ window.addEventListener('DOMContentLoaded', function() {
 		attach(fileList) {
 			const that = this
 
-			this._resizeFileActionMenu = _.debounce(_.bind(this._resizeFileActionMenu, this), 250) // eslint-disable-line
 			window.addEventListener('resize', function() {
 				that._resizeFileActionMenu(fileList)
 			})
@@ -33,6 +32,18 @@ window.addEventListener('DOMContentLoaded', function() {
 
 			fileList.$el.find('.selectedActions').detach().appendTo($thActions)
 			$thMenu.append(fileList.fileMultipleSelectionMenu.$el)
+
+			fileList.updateEmptyContent = function() {
+				const permissions = fileList.getDirectoryPermissions()
+				const isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0
+				fileList.$el.find('.emptyfilelist.emptycontent').toggleClass('hidden', !fileList.isEmpty)
+				fileList.$el.find('.emptyfilelist.emptycontent').toggleClass('hidden', !fileList.isEmpty)
+				fileList.$el.find('.emptyfilelist.emptycontent .uploadmessage').toggleClass('hidden', !isCreatable || !fileList.isEmpty)
+				fileList.$el.find('.files-filestable').toggleClass('hidden', fileList.isEmpty)
+				fileList.$el.find('.files-filestable thead th').toggleClass('hidden', fileList.isEmpty)
+				fileList.$el.find('.files-filestable thead th.column-menu').addClass('hidden')
+				fileList.$el.find('.files-filestable thead th.column-actions').addClass('hidden')
+			}
 
 			fileList.showDetailsView = function(fileName, tabId) {
 				that._updateDetailsView(fileName, fileList)

--- a/src/js/newfilemenuplugin.js
+++ b/src/js/newfilemenuplugin.js
@@ -57,8 +57,6 @@ window.addEventListener('DOMContentLoaded', function() {
 		},
 
 		_hideAllMenus(fileList) {
-			fileList.$el.find('.column-menu').addClass('hidden')
-			fileList.$el.find('.column-actions').addClass('hidden')
 			OC.hideMenus()
 			OCA.Files.Sidebar.close()
 		},


### PR DESCRIPTION
there was a bug in the multiselect menu. the menu was not closed after files are deleted and therefore no selection is active anymore.

the menu is now correctly closed after files are deleted.