### PR TITLE
Storage quota - show two digits after comma

### DIFF
--- a/src/components/StorageQuota.vue
+++ b/src/components/StorageQuota.vue
@@ -57,7 +57,7 @@ export default {
 			return parseFloat((this.storageStats?.used / this.storageStats?.quota) * 100).toFixed(2)
 		},
 		memoryUsage() {
-			return parseFloat((this.storageStats?.used / this.storageStats?.quota) * 100).toLocaleString(getCanonicalLocale())
+			return parseFloat((this.storageStats?.used / this.storageStats?.quota) * 100).toFixed(2).toLocaleString(getCanonicalLocale())
 		},
 	},
 	beforeMount() {


### PR DESCRIPTION
Format usage number to display only two digits after the decimal point