### PR TITLE
Adopt translation to changed message labels for V25

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -17,7 +17,7 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Erwartete Dateigröße von %1$s, aber %2$s gelesen (vom MagentaCLOUD-Client) und geschrieben (in den MagentaCLOUD-Speicher). Dies kann entweder ein Netzwerkproblem auf der sendenden Seite oder ein Problem beim Schreiben in den Speicher auf der Serverseite sein."
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "end_to_end_encryption": { "translations": {
-    "Reset End-to-End encryption" : "Verschlüsselung zurücksetzen",
+    "Reset end-to-end encryption" : "Verschlüsselung zurücksetzen",
     "Please read carefully before resetting your end-to-end encryption keys" : "Bitte vor dem Zurücksetzen Ihrer Schlüssel für die Ende-zu-Ende-Verschlüsselung aufmerksam lesen!",
     "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Sobald die Verschlüsselung zurückgesetzt wird, werden sämtliche verschlüsselten Dateien/Ordner gelöscht!",
     "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "Sofern die Passphrase vergessen wurde, kann diese in den Apps oder Desktop Clients der MagentaCLOUD ausgelesen werden. Eine Zurücksetzung ist nicht zwingend notwendig.",
@@ -28,7 +28,7 @@
     "End-to-End encryption is currently enabled and correctly setup." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
     "Cancel" : "Abbrechen",
     "Confirm" : "Bestätigen",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
+    "End-to-end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
     "You are not allowed to lock the root": "Das Sperren deines gesamten Verzeichnisbaumes durch E2E-Encryption wurde verhindert!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -17,7 +17,7 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Erwartete Dateigröße von %1$s, aber %2$s gelesen (vom MagentaCLOUD-Client) und geschrieben (in den MagentaCLOUD-Speicher). Dies kann entweder ein Netzwerkproblem auf der sendenden Seite oder ein Problem beim Schreiben in den Speicher auf der Serverseite sein."
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "end_to_end_encryption": { "translations": {
-    "Reset End-to-End encryption" : "Verschlüsselung zurücksetzen",
+    "Reset end-to-end encryption" : "Verschlüsselung zurücksetzen",
     "Please read carefully before resetting your end-to-end encryption keys" : "Bitte vor dem Zurücksetzen Ihrer Schlüssel für die Ende-zu-Ende-Verschlüsselung aufmerksam lesen!",
     "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Sobald die Verschlüsselung zurückgesetzt wird, werden sämtliche verschlüsselten Dateien/Ordner gelöscht!",
     "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "Sofern die Passphrase vergessen wurde, kann diese in den Apps oder Desktop Clients der MagentaCLOUD ausgelesen werden. Eine Zurücksetzung ist nicht zwingend notwendig.",
@@ -28,7 +28,7 @@
     "End-to-End encryption is currently enabled and correctly setup." : "Die Ende-zu-Ende Verschlüsselung ist derzeit aktiviert.",
     "Cancel" : "Abbrechen",
     "Confirm" : "Bestätigen",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
+    "End-to-end encryption is currently disabled. You can set it up with the {productName} clients." : "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
     "You are not allowed to lock the root": "Das Sperren deines gesamten Verzeichnisbaumes durch E2E-Encryption wurde verhindert!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -17,7 +17,7 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Expected filesize of %1$s but read (from MagentaCLOUD client) and wrote (to MagentaCLOUD storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side."
     },"pluralForm" :"nplurals=2; plural=(n != 1);" },
   "end_to_end_encryption": { "translations": {
-    "Reset End-to-End encryption" : "Reset encryption",
+    "Reset end-to-end encryption" : "Reset encryption",
     "Please read carefully before resetting your end-to-end encryption keys" : "Please read carefully before resetting your end-to-end encryption keys!",
     "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted.",
     "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "If you just forgot your passphrase, you can retrieve it in the MagentaCLOUD apps or desktop client. Key reset is not mandatory.",
@@ -28,7 +28,7 @@
     "End-to-End encryption is currently enabled and correctly setup." : "End to end encryption is currently enabled.",
     "Cancel" : "Cancel",
     "Confirm" : "Confirm",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
+    "End-to-end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
     "You are not allowed to lock the root": "The lock of your complete file tree by end2end encryption was prohibited by the system!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -17,7 +17,7 @@
     "Expected filesize of %1$s but read (from Nextcloud client) and wrote (to Nextcloud storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side." : "Expected filesize of %1$s but read (from MagentaCLOUD client) and wrote (to MagentaCLOUD storage) %2$s. Could either be a network problem on the sending side or a problem writing to the storage on the server side."
     },"pluralForm" :"nplurals=2; plural=(n != 1);" },
   "end_to_end_encryption": { "translations": {
-    "Reset End-to-End encryption" : "Reset encryption",
+    "Reset end-to-end encryption" : "Reset encryption",
     "Please read carefully before resetting your end-to-end encryption keys" : "Please read carefully before resetting your end-to-end encryption keys!",
     "Once your end-to-end encryption keys are reset, all files stored in your encrypted folder will be inaccessible." : "Once your encryption keys are reset, all encrypted data will be inaccessible and will be also deleted.",
     "You should only reset your end-to-end encryption keys if you lost your secure key words (mnemonic)." : "If you just forgot your passphrase, you can retrieve it in the MagentaCLOUD apps or desktop client. Key reset is not mandatory.",
@@ -28,7 +28,7 @@
     "End-to-End encryption is currently enabled and correctly setup." : "End to end encryption is currently enabled.",
     "Cancel" : "Cancel",
     "Confirm" : "Confirm",
-    "End to end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
+    "End-to-end encryption is currently disabled. You can set it up with the {productName} clients." : "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
     "You are not allowed to lock the root": "The lock of your complete file tree by end2end encryption was prohibited by the system!"
   },"pluralForm" :"nplurals=2; plural=(n != 1);"},
   "files": { "translations": {


### PR DESCRIPTION
On the upstream app, 2 labels have changed and are not overridden anymore.
(we should thing about having a unittest for overrides not applying anymore in the future)

Note that labels will change again for V27 ff, which is already derivable from repo state! 
