### PR TITLE
No search providers shown on UI

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -177,7 +177,7 @@ class Application extends App implements IBootstrap {
 						'settings',
 						'users',
 						'systemtags', // from apps/systemtags (first candidate to enable in the future!)
-                        'comments'    // from apps comments, (to enable as soon as comments is supported)
+						'comments'    // from apps comments, (to enable as soon as comments is supported)
 					]
 				);
 			});

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -176,7 +176,8 @@ class Application extends App implements IBootstrap {
 						'settings_apps', // from apps/settings
 						'settings',
 						'users',
-						'systemtags' // from apps/systemtags (first candidate to enable in the future!)
+						'systemtags', // from apps/systemtags (first candidate to enable in the future!)
+                        'comments'    // from apps comments, (to enable as soon as comments is supported)
 					]
 				);
 			});

--- a/lib/Search/SearchComposerDecorator.php
+++ b/lib/Search/SearchComposerDecorator.php
@@ -39,9 +39,9 @@ class SearchComposerDecorator extends SearchComposer {
 	 */
 	public function getProviders(string $route, array $routeParameters): array {
 		$providers = $this->decorated->getProviders($route, $routeParameters);
-		return array_filter($providers, function ($p) {
+		return array_values(array_filter($providers, function ($p) {
 			return !in_array($p['id'], $this->providerBlacklist);
-		});
+		}));
 	}
 
 	/**


### PR DESCRIPTION
`getProviders` delivered a result json which contained empty fields 8due to wrong php indexing).
This is fixed.

As comments are not delivered yet, but no mentioned in search help text, it is additionally blacklisted.