### PR TITLE
Restyle Unified Search & Results Popover

### DIFF
--- a/css/components/ncheadermenu.scss
+++ b/css/components/ncheadermenu.scss
@@ -51,9 +51,14 @@
                 background-color: var(--telekom-color-background-surface);
                 box-shadow: var(--telekom-shadow-raised-standard);
                 filter: none;
-                margin: 0 1rem;
+                margin: 0.5rem 2rem 0 0;
                 padding: 1rem;
                 top: calc(var(--header-height) + var(--external-margin));
+
+                
+                & > .header-menu__content {
+                    width: 492px;
+                }
             }
 
             @media screen and (max-width: $breakpoint-mobile) {

--- a/css/components/search.scss
+++ b/css/components/search.scss
@@ -1,0 +1,57 @@
+// styling for search popover from header
+
+.header-right {
+    .unified-search__input-wrapper label {
+        display: none;
+    }
+
+    .unified-search__input-wrapper ~ .empty-content {
+        display: none;
+    }
+
+    .empty-content {
+        &__icon > .material-design-icon.magnify-icon {
+            display: none;
+        }
+    }
+
+    .header-menu {
+        &__carret {
+            display: none;
+        }
+    }
+}
+
+.unified-search__form {
+    & #unified-search__input {
+        border: 2px solid black;
+        border-radius: 5px;
+        padding-top: 1.5rem;
+        padding-bottom: 1.5rem;
+        padding-left: 1rem;
+    }
+
+    & .unified-search__form-reset.icon-close {
+        background-image: var(--icon-close-x-dark);
+        opacity: 1;
+        margin: 12px 3px;
+    }
+}
+
+#header-menu-unified-search .header-menu__content .unified-search__results.unified-search__results-files {
+    & .unified-search__results-header {
+        color: #000000;
+        font-size: 16px;
+    }
+
+    & .unified-search__result {
+        border: none;
+
+        &:active,
+        &:hover,
+        &:focus {
+            background-color: var(--nmc-color-background-hover);
+            border: none;
+        }
+    }
+}

--- a/css/nmcstyle.scss
+++ b/css/nmcstyle.scss
@@ -36,6 +36,7 @@
 @import 'layouts/status.scss';
 @import 'layouts/conflictdialog.scss';
 @import 'layouts/guestview.scss';
+@import 'components/search.scss';
 
 /* special app stylings */
 @import 'apps/apps.scss';


### PR DESCRIPTION
https://jira.telekom.de/browse/NMC-2561

- Had to use !important a few times in search.scss, in order to override the styling in the following "core" components: SearchResult.vue & UnifiedSearch.vue --> Open to suggestions if we can do this any better way.

![image](https://github.com/nextmcloud/nmctheme/assets/143171366/537704db-bb91-4711-bf93-70431061c67b)
