### PR TITLE
fixed csp listener

### DIFF
--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -7,22 +7,19 @@ namespace OCA\NMCTheme\Listener;
 use OC\Security\CSP\ContentSecurityPolicy;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IConfig;
 use OCP\IRequest;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
 class CSPListener implements IEventListener {
 
 	private IRequest $request;
-	private IConfig $iConfig;
 	private function isPageLoad(): bool {
 		$scriptNameParts = explode('/', $this->request->getScriptName());
 		return end($scriptNameParts) === 'index.php';
 	}
 
-	public function __construct(IRequest $request, IConfig $iConfig) {
+	public function __construct(IRequest $request) {
 		$this->request = $request;
-		$this->iConfig = $iConfig;
 	}
 
 	public function handle(Event $event): void {
@@ -32,12 +29,13 @@ class CSPListener implements IEventListener {
 		if (!$this->isPageLoad()) {
 			return;
 		}
-		$response = $event->getResponse();
 
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedImageDomain('\'self\'');
 		$csp->addAllowedMediaDomain('\'self\'');
 		$csp->addAllowedConnectDomain('\'self\'');
-		$response->setContentSecurityPolicy($csp);
+
+		//Add the policy to the event
+		$event->addPolicy($csp);
 	}
 }


### PR DESCRIPTION
the cps lister causes a fatal error by calling the undefined function getResponse.
The AddContentSecurityPolicyEvent delivers no response therefore this method has to be removed,
Instead the new policy settings hve to be added to the event.