### PR TITLE
Restyle Login Grant Window and small changes in Media Add Photo Modal and 3-Dot-Menu

### DIFF
--- a/css/apps/photos.scss
+++ b/css/apps/photos.scss
@@ -398,6 +398,19 @@
 
 // Add Photos modal window
 #body-user .modal-container .file-picker {
+	& + button.modal-container__close {
+		z-index: 10;
+		margin-right: 0.5rem;
+		margin-top: 0.5rem;
+		background-image: var(--icon-close-dark);
+		background-position: center;
+		background-repeat: no-repeat;
+
+		span[role="img"] {
+			display: none;
+		}
+	}
+
 	&__actions {
 		flex-direction: row-reverse;
 

--- a/css/components/ncactions.scss
+++ b/css/components/ncactions.scss
@@ -44,4 +44,9 @@
 			}
 		}
 	}
+
+	// hide upload file menu item in Photos Album
+	li[data-upload-picker-add=""]{
+		display: none;
+	}
 }

--- a/css/login/grant.scss
+++ b/css/login/grant.scss
@@ -1,0 +1,24 @@
+@import '../_mixins.scss';
+@import '../variables';
+
+.picker-window.small {
+    background: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(5px);
+    position: relative;
+    top: 18vh;
+    padding-bottom: 2.5rem;
+
+    @media screen and (max-width: $breakpoint-mobile-small) {
+        top: 10vh;
+    }
+
+    p:first-child {
+        display: none;
+    }
+
+    #redirect-link {
+        #submit-wrapper {
+            @include primary-button;  
+        }
+    }
+}

--- a/css/nmcstyle.scss
+++ b/css/nmcstyle.scss
@@ -51,6 +51,9 @@
 @import 'apps/rich-workspace.scss';
 @import 'apps/files-right-click.scss';
 
+/* login confirmation windows */
+@import 'login/grant.scss';
+
 /* v25 override */
 @import 'v25/ncappnavigation.scss';
 @import 'v25/header.scss';


### PR DESCRIPTION
https://jira.telekom.de/browse/NMC-2807
As there was no way to test the login grant window locally, used the grant.php template as reference for the restyle.

PR includes:
- "fix close button style (as discussed in Review call 21.11) " from https://jira.telekom.de/browse/NMC-2765
- ""Add photos to album" leads directly to Add photos modal (no dropdown anymore)  (as discussed in Review Call 21.11, we can only remove the Upload files menu item, this is now done LP 22.11)" from https://jira.telekom.de/browse/NMC-2762

![image](https://github.com/nextmcloud/nmctheme/assets/143171366/3b6ac8d9-8d4c-4fa9-90b4-a056c5716f59)
![image](https://github.com/nextmcloud/nmctheme/assets/143171366/f6595812-6cd8-4815-a3e9-e058368ef364)

