### PR TITLE
added uppercase translation variant

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -41,6 +41,7 @@
       "Cancel": "Abbrechen",
       "Confirm": "Bestätigen",
       "End-to-end encryption is currently disabled. You can set it up with the {productName} clients.": "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
+      "End-to-End encryption is currently disabled. You can set it up with the {productName} clients.": "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
       "You are not allowed to lock the root": "Das Sperren deines gesamten Verzeichnisbaumes durch E2E-Encryption wurde verhindert!"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
@@ -189,7 +190,16 @@
       "Show folder info text": "Ordnerinfotext anzeigen",
       "Shared with you": "Mit mir geteilt",
       "Shared with others": "Meine geteilten Inhalte",
-      "and": "und"
+      "and": "und",
+      "System Design (Standard)" : "System-Design (Standard)",
+      "Enable system design" : "System-Design aktivieren",
+      "MagentaCLOUD adapts to the settings of your system." : "MagentaCLOUD passt sich den Einstellungen Ihres Systems an.",
+      "Light Design" : "Helles Design",
+      "Enable light design" : "Helles Design aktivieren",
+      "A bright black on white design." : "Ein helles schwarz auf weiß Design.",
+      "Dark Design" : "Dunkles Design",
+      "Enable dark design" : "Dunkles Design aktivieren",
+      "A dark design to relieve eye strain." : "Ein dunkles Design zur Entlastung der Augen."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
   }

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -41,6 +41,7 @@
       "Cancel": "Abbrechen",
       "Confirm": "Bestätigen",
       "End-to-end encryption is currently disabled. You can set it up with the {productName} clients.": "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
+      "End-to-End encryption is currently disabled. You can set it up with the {productName} clients.": "Die Ende-zu-Ende Verschlüsselung ist deaktiviert. Sie können sie in den MagentaCLOUD Apps oder Desktop Clients einrichten.",
       "You are not allowed to lock the root": "Das Sperren deines gesamten Verzeichnisbaumes durch E2E-Encryption wurde verhindert!"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
@@ -189,7 +190,16 @@
       "Show folder info text": "Ordnerinfotext anzeigen",
       "Shared with you": "Mit mir geteilt",
       "Shared with others": "Meine geteilten Inhalte",
-      "and": "und"
+      "and": "und",
+      "System Design (Standard)" : "System-Design (Standard)",
+      "Enable system design" : "System-Design aktivieren",
+      "MagentaCLOUD adapts to the settings of your system." : "MagentaCLOUD passt sich den Einstellungen Ihres Systems an.",
+      "Light Design" : "Helles Design",
+      "Enable light design" : "Helles Design aktivieren",
+      "A bright black on white design." : "Ein helles schwarz auf weiß Design.",
+      "Dark Design" : "Dunkles Design",
+      "Enable dark design" : "Dunkles Design aktivieren",
+      "A dark design to relieve eye strain." : "Ein dunkles Design zur Entlastung der Augen."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
   }

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -41,6 +41,7 @@
       "Cancel": "Cancel",
       "Confirm": "Confirm",
       "End-to-end encryption is currently disabled. You can set it up with the {productName} clients.": "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
+      "End-to-End encryption is currently disabled. You can set it up with the {productName} clients.": "End-to-End encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
       "You are not allowed to lock the root": "The lock of your complete file tree by end2end encryption was prohibited by the system!"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
@@ -189,7 +190,16 @@
       "Show folder info text": "Show folder info text",
       "Shared with you": "Shared with me",
       "Shared with others": "My shares",
-      "and": "and"
+      "and": "and",
+      "System Design (Standard)" : "System Design (Standard)",
+      "Enable system design" : "Enable system design",
+      "MagentaCLOUD adapts to the settings of your system." : "MagentaCLOUD adapts to the settings of your system.",
+      "Light Design" : "Light Design",
+      "Enable light design" : "Enable light design",
+      "A bright black on white design." : "A bright black on white design.",
+      "Dark Design" : "Dark Design",
+      "Enable dark design" : "Enable dark design",
+      "A dark design to relieve eye strain." : "A dark design to relieve eye strain."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
   }

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -41,6 +41,7 @@
       "Cancel": "Cancel",
       "Confirm": "Confirm",
       "End-to-end encryption is currently disabled. You can set it up with the {productName} clients.": "End-to-end encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
+      "End-to-End encryption is currently disabled. You can set it up with the {productName} clients.": "End-to-End encryption is currently disabled. You can set it up with MagentaCLOUD clients.",
       "You are not allowed to lock the root": "The lock of your complete file tree by end2end encryption was prohibited by the system!"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
@@ -189,7 +190,16 @@
       "Show folder info text": "Show folder info text",
       "Shared with you": "Shared with me",
       "Shared with others": "My shares",
-      "and": "and"
+      "and": "and",
+      "System Design (Standard)" : "System Design (Standard)",
+      "Enable system design" : "Enable system design",
+      "MagentaCLOUD adapts to the settings of your system." : "MagentaCLOUD adapts to the settings of your system.",
+      "Light Design" : "Light Design",
+      "Enable light design" : "Enable light design",
+      "A bright black on white design." : "A bright black on white design.",
+      "Dark Design" : "Dark Design",
+      "Enable dark design" : "Enable dark design",
+      "A dark design to relieve eye strain." : "A dark design to relieve eye strain."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
   }


### PR DESCRIPTION
there are two different variations of the same translation key for the encryption text, which depends which version of the end to end encryption app is deployed.

additionally some translations that are needed for the theming page are included.