### PR TITLE
Fix trashbin icon cutoff for welcome popup settings

### DIFF
--- a/css/apps/settings.scss
+++ b/css/apps/settings.scss
@@ -654,6 +654,12 @@ body .icon-auto-login-dark {
 					@include primary-button;
 					background-image: var(--icon-upload-white);
 				}
+			.icon-delete {
+				background-image: var(--icon-delete-dark);
+				background-repeat: no-repeat;
+				background-position: center;
+				background-size: 1rem;
+			}
 		}
 	}
 


### PR DESCRIPTION
![image](https://github.com/nextmcloud/nmctheme/assets/143171366/d182ec3e-aec4-4035-8af3-edc81766fab2)
