### PR TITLE
created alternative touch icon route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,5 +23,11 @@ return [
 			'url' => '/mime/img/{iconname}.svg',
 			'verb' => 'GET',
 		],
+		[
+			'name' => 'TouchIcon#getTouchIcon',
+			'url' => '/touchicon/{app}',
+			'verb' => 'GET',
+			'defaults' => ['app' => 'nmctheme'],
+		],
 	]
 ];

--- a/lib/Controller/TouchIconController.php
+++ b/lib/Controller/TouchIconController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OCA\NMCTheme\Controller;
 
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
@@ -15,7 +16,7 @@ class TouchIconController extends Controller {
 	private $fileAccessHelper;
 
 	/** @var IAppManager */
-	private  $appManager;
+	private $appManager;
 
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/TouchIconController.php
+++ b/lib/Controller/TouchIconController.php
@@ -1,0 +1,51 @@
+<?php
+namespace OCA\NMCTheme\Controller;
+
+use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use OCA\NMCTheme\AppInfo\Application;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\IRequest;
+
+class TouchIconController extends Controller {
+	/** @var FileAccessHelper */
+	private $fileAccessHelper;
+
+	/** @var IAppManager */
+	private  $appManager;
+
+	public function __construct(
+		IRequest $request,
+		FileAccessHelper $fileAccessHelper,
+		IAppManager $appManager,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+		$this->fileAccessHelper = $fileAccessHelper;
+		$this->appManager = $appManager;
+	}
+
+	/**
+	 * Return a 512x512 icon for touch devices
+	 *
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * @param string $app ID of the app
+	 * @return DataDisplayResponse<Http::STATUS_OK, array{Content-Type: 'image/png'}>|FileDisplayResponse<Http::STATUS_OK, array{Content-Type: 'image/x-icon'|'image/png'}>|NotFoundResponse<Http::STATUS_NOT_FOUND, array{}>
+	 *
+	 * 200: Touch icon returned
+	 * 404: Touch icon not found
+	 */
+	public function getTouchIcon(string $app = 'core'): Response {
+
+		$touchIconPath = $this->appManager->getAppPath(Application::APP_ID) . "/img/";
+		$iconFile = $this->fileAccessHelper->file_get_contents($touchIconPath . 'favicon-touch.png');
+		$response = new DataDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/png']);
+		$response->cacheFor(86400);
+
+		return $response;
+	}
+}

--- a/lib/URLGeneratorDecorator.php
+++ b/lib/URLGeneratorDecorator.php
@@ -37,6 +37,10 @@ class URLGeneratorDecorator implements IURLGenerator {
 	 * No decoration, only delegate.
 	 */
 	public function linkToRoute(string $routeName, array $arguments = []): string {
+		if ($routeName === 'theming.Icon.getTouchIcon') {
+			return $this->decorated->linkToRoute('nmctheme.TouchIcon.getTouchIcon', $arguments);
+		}
+
 		return $this->decorated->linkToRoute($routeName, $arguments);
 	}
 


### PR DESCRIPTION
FIXES: https://jira.telekom.de/browse/NMC-3047

In order to replace the touch icon that is used for the sharelink preview, when pasted into messengers etc.
we replaced the route that is called from standard theming manifest file with our custom one.

Our current customizations have not had any effect, because the imagePath method is not used to access the file.