### PR TITLE
Fix cache buster for nmctheme css files

### DIFF
--- a/lib/Themes/Magenta.php
+++ b/lib/Themes/Magenta.php
@@ -11,18 +11,23 @@ declare(strict_types=1);
 namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
+use OCA\Theming\Util;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class Magenta implements ITheme {
+	protected Util $themingUtil;
 	protected IAppManager $appManager;
 	protected IURLGenerator $urlGenerator;
 	protected IL10N $l;
 
-	public function __construct(IAppManager $appManager,
+	public function __construct(
+		Util $themingUtil,
+		IAppManager $appManager,
 		IURLGenerator $urlGenerator,
 		IL10N $l) {
+		$this->themingUtil = $themingUtil;
 		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;
 		$this->l = $l;
@@ -67,7 +72,13 @@ class Magenta implements ITheme {
 		$iconsVariables = $this->urlGenerator->linkTo('nmctheme', 'dist/icons.css');
 		$themeStyle = $this->urlGenerator->linkTo('nmctheme', 'css/nmcstyle.css');
 
-		
+		$cacheBuster = $this->themingUtil->getCacheBuster();
+
+		$telekomVariables .= '?nmcv=' . $cacheBuster;
+		$themeVariables .= '?nmcv=' . $cacheBuster;
+		$iconsVariables .= '?nmcv=' . $cacheBuster;
+		$themeStyle .= '?nmcv=' . $cacheBuster;
+
 		return "
 			@import url('{$telekomVariables}');
 			@import url('{$themeVariables}');

--- a/lib/Themes/MagentaDark.php
+++ b/lib/Themes/MagentaDark.php
@@ -12,17 +12,19 @@ declare(strict_types=1);
 namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
+use OCA\Theming\Util;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class MagentaDark extends Magenta implements ITheme {
 	public function __construct(
+		Util $themingUtil,
 		IAppManager $appManager,
 		IURLGenerator $urlGenerator,
 		IL10N $l
 	) {
-		parent::__construct($appManager, $urlGenerator, $l);
+		parent::__construct($themingUtil, $appManager, $urlGenerator, $l);
 	}
 
 	public function getId(): string {

--- a/lib/Themes/MagentaLight.php
+++ b/lib/Themes/MagentaLight.php
@@ -12,17 +12,19 @@ declare(strict_types=1);
 namespace OCA\NMCTheme\Themes;
 
 use OCA\Theming\ITheme;
+use OCA\Theming\Util;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class MagentaLight extends Magenta implements ITheme {
 	public function __construct(
+		Util $themingUtil,
 		IAppManager $appManager,
 		IURLGenerator $urlGenerator,
 		IL10N $l
 	) {
-		parent::__construct($appManager, $urlGenerator, $l);
+		parent::__construct($themingUtil, $appManager, $urlGenerator, $l);
 	}
 
 	public function getId(): string {


### PR DESCRIPTION
The cache buster was implemented at runtime by generating URLs using PHP and appending a dynamic version and injected into the response as dynamic @import statements.
This way, the browser sees a new URL whenever the cache buster is executed (e.g. after a deployment), and loads the latest file instead of the cached one.