### PR TITLE
fix trashbin table header colors

### DIFF
--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -309,10 +309,13 @@ table.files-filestable {
 
 /*------------------------------------ v28 - specific styling ------------------------------------*/
 #body-user {
+
 	// files modal search input
 	.modal-mask.dialog__modal {
 		& .modal-wrapper.modal-wrapper--large {
-			input, .input-field__main-wrapper .input-field__input {
+
+			input,
+			.input-field__main-wrapper .input-field__input {
 				padding-left: 2.5rem;
 			}
 		}
@@ -582,8 +585,9 @@ table.files-filestable {
 						@include files-table-columns-v28;
 					}
 
+					
+					&row-size,					
 					&row-mtime,
-					&row-size,
 					&row-trashbin-original-location,
 					&row-trashbin-deleted {
 						min-width: 140px;
@@ -596,6 +600,34 @@ table.files-filestable {
 
 						@include files-table-columns-v28;
 					}
+				}
+
+				th:nth-of-type(7) {
+					span.button-vue__wrapper {
+						padding-bottom: 5px;
+
+						svg {
+							color: var(--color-text-maxcontrast);
+							opacity: 1;
+							display: block;
+							visibility: visible;
+						}
+
+						span.files-list__column-sort-button-text {
+							color: var(--color-main-text);
+						}
+
+						&:hover {
+							svg {
+								color: var(--telekom-color-text-and-icon-primary-standard);
+							}
+
+							span.files-list__column-sort-button-text {
+								color: var(--telekom-color-text-and-icon-primary-standard);
+							}
+						}
+					}
+
 				}
 			}
 
@@ -684,7 +716,7 @@ table.files-filestable {
 							text-align: start;
 							width: 100%;
 							height: 100%;
-    						min-height: 36px;
+							min-height: 36px;
 							min-width: 0;
 							margin: 0;
 							padding: 8px 14px;
@@ -774,7 +806,7 @@ table.files-filestable {
 											@include magenta-icon;
 										}
 
-										&.button-vue--icon-and-text[aria-label="Mit mir geteilt"] .button-vue__icon, 
+										&.button-vue--icon-and-text[aria-label="Mit mir geteilt"] .button-vue__icon,
 										&.button-vue--icon-and-text[aria-label="Shared with me"] .button-vue__icon {
 											background-image: var(--icon-upload-to-cloud-dark);
 											filter: invert(61%) sepia(98%) saturate(4546%) hue-rotate(181deg) brightness(99%) contrast(109%);
@@ -845,13 +877,13 @@ table.files-filestable {
 					}
 
 					td.files-list__row-actions {
-							width: 1.5rem;
+						width: 1.5rem;
 
-							.action-item__menutoggle {
-								padding: 0;
-								min-width: 1.5rem;
-								width: 1.5rem !important;
-							}
+						.action-item__menutoggle {
+							padding: 0;
+							min-width: 1.5rem;
+							width: 1.5rem !important;
+						}
 					}
 
 					.files-list__row-icon {
@@ -1024,7 +1056,9 @@ table.files-filestable {
 		// 3-dot menu on rows
 		.v-popper__popper--shown .v-popper__wrapper .v-popper__inner {
 			ul[role="menu"] {
-				li.files-list__row-action.files-list__row-action-rename, li.files-list__row-action-sharing-status {
+
+				li.files-list__row-action.files-list__row-action-rename,
+				li.files-list__row-action-sharing-status {
 					display: none;
 				}
 			}

--- a/css/layouts/header.scss
+++ b/css/layouts/header.scss
@@ -68,9 +68,37 @@ header {
 	#header-left,
 	.header-left {
 		.app-menu {
-			&-entry {
+			    width: 100%;
+    			display: flex;
+   				flex-shrink: 1;
+    			flex-wrap: wrap;
+		&-entry {
 				&--label {
 					font-weight: 800;
+				}
+			}
+
+			button.action-item__menutoggle {
+				height: 32px;
+				width: 32px !important;
+				min-height: 32px;
+				min-width: 32px;
+
+				background-image: var(--icon-menu-dark);
+    			background-size: auto 24px;
+    			background-position: center;
+    			background-repeat: no-repeat;
+
+				svg {
+					display: none;
+				}
+
+				.button-vue__wrapper {
+					display: none;
+				}
+
+				&[aria-expanded="true"] {
+					background-image: var(--icon-close-dark);
 				}
 			}
 		}


### PR DESCRIPTION
Fixed following from bug collection ticket 3:

**Resolution <= 1024 (Header Navigation)**

- "Files and Photos" disappear from Main Navigation (Burger Menu on the right side is missing) <-- burger menu still not showing up in light mode. Same colors and icon used as on Production (--icon-menu-dark)

**Resolution <= 1024 (Trashbin)**

- Table does not adjust automatically (right left scrolling is possible) (could not reproduce issue- not sure what it relates to)

**Trashbin**

- Shows a broken user icon (could not reproduce issue- not sure what it relates to)

- Table header „deleted by“ -> different font color, vertical alignment not correct (fixed colors, modifying margins for table column headers in trashbin affects alignment in All Files view. Currently no way to separate between Size and Modified columns in Trashbin from the ones in All Files. Modifying alignment in Trashbin consequently affects the alignment in All Files view and vice-versa)

![image](https://github.com/user-attachments/assets/d08b45c5-b833-4415-91d6-d1b8b0f6244e)
![image](https://github.com/user-attachments/assets/015d694a-511a-4c59-93e4-0a7210ef846f)

