### PR TITLE
Update folder icon design to new blue style

### DIFF
--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -503,7 +503,7 @@ table.files-filestable {
 								position: absolute;
 
 								&.folder-icon {
-									background-image: var(--icon-mime-folder-dark);
+									background-image: var(--icon-mime-folder-blue);
 								}
 
 								&.files-list__row-icon-overlay {
@@ -697,7 +697,7 @@ table.files-filestable {
 					@include thumbnail-icons();
 
 					&.folder-icon {
-						background-image: var(--icon-mime-folder-dark);
+						background-image: var(--icon-mime-folder-blue);
 					}
 
 					&.files-list__row-icon-overlay {
@@ -967,7 +967,7 @@ table.files-filestable {
 				z-index: 100;
 
 				.material-design-icon.folder-icon {
-					background-image: var(--icon-mime-folder-dark);
+					background-image: var(--icon-mime-folder-blue);
 					@include thumbnail-icons();
 				}
 			}

--- a/css/apps/files_sharing.scss
+++ b/css/apps/files_sharing.scss
@@ -17,7 +17,7 @@
         }
 
         #displayavatar .icon-folder {
-            background-image: var(--icon-mime-folder-dark);
+            background-image: var(--icon-mime-folder-blue);
             background-size: 192px;
             height: 128px;
             width: 128px;

--- a/css/apps/photos.scss
+++ b/css/apps/photos.scss
@@ -326,7 +326,7 @@
 
 							// replace standart folder icon
 							span.icon-folder {
-								background-image: var(--icon-mime-folder-dark);
+								background-image: var(--icon-mime-folder-blue);
 								opacity: 1;
 							}
 
@@ -1136,7 +1136,7 @@
 					}
 
 					&.folder-icon {
-						background-image: var(--icon-mime-folder-dark);
+						background-image: var(--icon-mime-folder-blue);
 						@include thumbnail-icons();
 					}
 

--- a/img/filetypes/folder.svg
+++ b/img/filetypes/folder.svg
@@ -1,35 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72 72">
-  <defs>
-    <style>
-      .cls-1 {
-        fill: #53baf2;
-      }
-
-      .cls-1, .cls-2, .cls-3 {
-        stroke-width: 0px;
-      }
-
-      .cls-2 {
-        fill: url(#Unbenannter_Verlauf_12);
-      }
-
-      .cls-3 {
-        fill: #317cb3;
-        isolation: isolate;
-        opacity: .25;
-      }
-    </style>
-    <linearGradient id="Unbenannter_Verlauf_12" data-name="Unbenannter Verlauf 12" x1="-162.95" y1="-157.18" x2="-162.95" y2="-207.21" gradientTransform="translate(198.95 222.55)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#53baf2"/>
-      <stop offset="1" stop-color="#7ecbf5"/>
-    </linearGradient>
-  </defs>
-  <g id="Icons">
-    <g>
-      <path class="cls-1" d="m23.14,6.43H2.57c-1.41,0-2.57,1.16-2.57,2.57v6.43h32.14l-9-9Z"/>
-      <path class="cls-3" d="m23.14,6.43H2.57c-1.41,0-2.57,1.16-2.57,2.57v6.43h32.14l-9-9Z"/>
-      <path class="cls-2" d="m69.43,15.43H0v47.57c0,1.41,1.16,2.57,2.57,2.57h66.86c1.41,0,2.57-1.16,2.57-2.57V18c0-1.41-1.16-2.57-2.57-2.57Z"/>
-    </g>
-  </g>
+<svg width="45" height="36" viewBox="0 0 45 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 0H4.5C2.0025 0 0 2.0025 0 4.5V31.5C0 32.6935 0.474106 33.8381 1.31802 34.682C2.16193 35.5259 3.30653 36 4.5 36H40.5C41.6935 36 42.8381 35.5259 43.682 34.682C44.5259 33.8381 45 32.6935 45 31.5V9C45 6.5025 42.975 4.5 40.5 4.5H22.5L18 0Z" fill="#84B0F5"/>
 </svg>

--- a/src/icons.mjs
+++ b/src/icons.mjs
@@ -20,6 +20,7 @@ const colors = {
 	success: '00b367',
 	danger: 'e82010',
 	warning: 'f97012',
+	blue: '84B0F5',
 }
 
 const colorSvg = function(svg = '', color = '000') {
@@ -82,7 +83,6 @@ const icons = {
 	user: path.join(__dirname, '../img', 'actions', 'user.svg'),
 	folder: path.join(__dirname, '../img', 'actions', 'folder.svg'),
 	'folder-description': path.join(__dirname, '../img', 'actions', 'folder-description.svg'),
-	'mime-folder': path.join(__dirname, '../img', 'filetypes', 'folder.svg'),
 	'mime-folder-audio': path.join(__dirname, '../img', 'filetypes', 'folder-audio.svg'),
 	'mime-folder-encrypted': path.join(__dirname, '../img', 'filetypes', 'folder-encrypted.svg'),
 	'mime-folder-photo': path.join(__dirname, '../img', 'filetypes', 'folder-photo.svg'),
@@ -217,6 +217,10 @@ const iconsColor = {
 	danger: {
 		path: path.join(__dirname, '../img', 'rich-workspace', 'danger.svg'),
 		color: 'danger',
+	},
+	'mime-folder': {
+		path: path.join(__dirname, '../img', 'filetypes', 'folder.svg'),
+		color: 'blue',
 	},
 }
 


### PR DESCRIPTION
- Replace folder.svg with new blue folder icon design
- Add blue color (#84B0F5) to icons color palette
- Move mime-folder to iconsColor to preserve blue color
- Update all folder icon references from dark to blue variant
- Apply changes across files, photos, and sharing apps