### PR TITLE
Nmc/5310 footer adjustments

### DIFF
--- a/css/components/ncappnavigation.scss
+++ b/css/components/ncappnavigation.scss
@@ -87,7 +87,7 @@
 
 	.app-navigation-entry__settings {
 
-		padding: 0 0 1rem;
+		padding: 0 0 calc(46px + 0.5rem);
 
 		> li {
 			display: none;

--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -53,6 +53,10 @@ footer[role="contentinfo"] {
         gap: 5rem;
         line-height: 1.5rem;
 
+        @media screen and (max-width: $breakpoint-mobile) {
+            gap: 1.5rem;
+        }
+
         @media screen and (max-width: $breakpoint-mobile-small) {
             gap: 0.5rem;
             font-size: 0.875rem;

--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -20,32 +20,47 @@ footer {
 
 footer[role="contentinfo"] {
     background-color: var(--color-main-background);
-    display: none;
+    display: block;
     font: var(--footer-font);
     position: fixed;
     left: 0;
     right: 0;
     bottom: 0;
-    max-height: 60px;
-    max-width: calc(100% - 2rem);
+    height: 46px;
+    width: 100%;
     z-index: 998;
     border-top: 1px solid var(--color-border);
-    padding: 1.5rem;
+    padding: 0.5rem 1.5rem;
+    box-sizing: border-box;
 
-    @media screen and (max-width: $breakpoint-mobile-small) {
-        padding: 1rem;
-        max-width: 100%;
+    @media screen and (max-width: $breakpoint-mobile) {
+        height: auto;
+        min-height: 46px;
     }
 
-    .footer-content {        
+    @media screen and (max-width: $breakpoint-mobile-small) {
+        padding: 0.5rem 1rem;
+    }
+
+    @media screen and (max-width: 400px) {
+        padding: 0.25rem 0.5rem;
+    }
+
+    .footer-content {
         align-content: center;
         display: flex;
         flex-wrap: wrap;
-        gap: 1.5rem;
+        gap: 5rem;
         line-height: 1.5rem;
 
         @media screen and (max-width: $breakpoint-mobile-small) {
             gap: 0.5rem;
+            font-size: 0.875rem;
+        }
+
+        @media screen and (max-width: 400px) {
+            gap: 0.25rem;
+            font-size: 0.75rem;
         }
 
         #notice {
@@ -61,7 +76,15 @@ footer[role="contentinfo"] {
             gap: 1.5rem;
 
             @media screen and (max-width: $breakpoint-mobile-small) {
-                gap: 0.5rem;
+                flex-wrap: nowrap;
+                gap: 0.25rem;
+                justify-content: flex-start;
+                font-size: 0.75rem;
+            }
+
+            @media screen and (max-width: 400px) {
+                gap: 0.125rem;
+                font-size: 0.75rem;
             }
         }
 
@@ -69,6 +92,17 @@ footer[role="contentinfo"] {
             font: var(--footer-font); // override NC guest.scss
             padding: 0.5rem;
             margin: calc(-1 * 0.5rem) 0;
+
+            @media screen and (max-width: $breakpoint-mobile-small) {
+                padding: 0.25rem;
+                margin: calc(-1 * 0.25rem) 0;
+            }
+
+            @media screen and (max-width: 400px) {
+                padding: 0.125rem;
+                margin: calc(-1 * 0.125rem) 0;
+                font-size: 0.75rem;
+            }
         }
 
         li a:hover {

--- a/css/layouts/guestview.scss
+++ b/css/layouts/guestview.scss
@@ -61,17 +61,22 @@
     footer[role="contentinfo"] {
         background-color: var(--color-main-background);
         border-radius: 0px 0px 0.5rem 0.5rem;
-        box-sizing: unset;
+        box-sizing: border-box;
         font: var(--footer-font);
         position: fixed;
         left: 1rem;
         right: 1rem;
         bottom: 24px;
-        max-height: 60px;
+        height: 46px;
         max-width: calc(100% - 4rem);
         z-index: 998;
         border-top: 1px solid var(--color-border);
-        padding: 16px 16px;
+        padding: 0.5rem 1rem;
+
+        @media screen and (max-width: $breakpoint-mobile) {
+            height: auto;
+            min-height: 46px;
+        }
 
         @media screen and (max-width: $breakpoint-mobile-small) {
             border-radius: 0;


### PR DESCRIPTION
  Restored footer visibility and implemented responsive layout for all device sizes.
  - Restored footer display and reduced height to 46px
  - Added responsive breakpoints for desktop, tablet, mobile, and extra-small screens
  - Fixed tablet spacing issue (reduced gap from 5rem to 1.5rem on iPad Mini)
  - Optimized font sizes and spacing for mobile devices (no text wrapping)
  - Adjusted app navigation padding to prevent footer from hiding storage quota