### PR TITLE
fix: update folder icon color in link bubble view

### DIFF
--- a/css/apps/rich-workspace.scss
+++ b/css/apps/rich-workspace.scss
@@ -473,6 +473,7 @@
 
 		.tippy-box {
 			max-width: 100% !important;
+			z-index: 9999 !important;
 
 			.menububble {
 

--- a/css/apps/rich-workspace.scss
+++ b/css/apps/rich-workspace.scss
@@ -465,15 +465,8 @@
 			}
 		}
 
-		.link-view-bubble {
-		.folder-icon svg {
-			fill: var(--nmc-ods-blue);;
-		}
-	}
-
 		.tippy-box {
 			max-width: 100% !important;
-			z-index: 9999 !important;
 
 			.menububble {
 
@@ -508,5 +501,13 @@
 				}
 			}
 		}
+	}
+}
+
+// Folder icon color in link bubble — selector is global because the bubble
+// is moved to document.body by the nmcfiles.ts MutationObserver fix.
+.link-view-bubble {
+	.folder-icon svg {
+		fill: var(--nmc-ods-blue);
 	}
 }

--- a/css/apps/rich-workspace.scss
+++ b/css/apps/rich-workspace.scss
@@ -465,6 +465,12 @@
 			}
 		}
 
+		.link-view-bubble {
+		.folder-icon svg {
+			fill: var(--nmc-ods-blue);;
+		}
+	}
+
 		.tippy-box {
 			max-width: 100% !important;
 

--- a/src/nmcfiles.ts
+++ b/src/nmcfiles.ts
@@ -90,6 +90,35 @@ function updateLabel(selector) {
 	return false
 }
 
+/**
+ * Move the text editor link bubble tooltip to document.body to escape
+ * the CSS stacking context and appear above the app navigation.
+ */
+function setupLinkBubbleFix(): void {
+	const observer = new MutationObserver((mutations: MutationRecord[]) => {
+		for (const mutation of mutations) {
+			for (const node of Array.from(mutation.addedNodes)) {
+				if (!(node instanceof Element)) continue
+				const candidates = node.matches('[data-tippy-root]')
+					? [node]
+					: Array.from(node.querySelectorAll('[data-tippy-root]'))
+				for (const root of candidates) {
+					if (root.parentNode !== document.body && root.querySelector('.link-view-bubble')) {
+						document.body.appendChild(root)
+					}
+				}
+			}
+		}
+	})
+	observer.observe(document.body, { childList: true, subtree: true })
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', setupLinkBubbleFix)
+} else {
+	setupLinkBubbleFix()
+}
+
 window.addEventListener('DOMContentLoaded', function() {
 	const breadcrumb = document.querySelector('.breadcrumb')
 	const empty = document.querySelector('.files-list__empty')


### PR DESCRIPTION
- Add MutationObserver in nmcfiles.ts to move the link bubble tippy root
  to document.body, escaping the editor's CSS stacking context
- Move folder icon CSS rule to global scope so it matches after the
  bubble is relocated to document.body