### PR TITLE
feat: 5422 filter three-dot menu to accept/reject only on pending share rows

### DIFF
--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1427,7 +1427,8 @@ table.files-filestable {
 				}
 			}
 
-			// Hide sharing-popup and actions menu for pending share rows
+			// Pending share rows: disable name link interaction to prevent opening the file
+			// and navigating away from the pending shares view
 			tbody tr:has(.files-list__row-action-accept-share) {
 				td.files-list__row-actions {
 					.action-items {
@@ -1446,6 +1447,14 @@ table.files-filestable {
 				}
 			}
 		}
+	}
+}
+
+// Pending shares page: disable name link so files cannot be opened before accepting the share
+body.nmc-pendingshares-view {
+	.files-list__row-name-link {
+		pointer-events: none;
+		cursor: default;
 	}
 }
 

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1456,6 +1456,11 @@ body.nmc-pendingshares-view {
 		pointer-events: none;
 		cursor: default;
 	}
+
+	.files-list:not(.files-list--grid) .files-list__row-icon .material-design-icon svg {
+		width: 44px !important;
+		height: 36px !important;
+	}
 }
 
 #body-user,

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1461,6 +1461,13 @@ body.nmc-pendingshares-view {
 		width: 44px !important;
 		height: 36px !important;
 	}
+
+	.files-list__row-actions-batch-move-copy,
+	.files-list__row-actions-batch-download,
+	.files-list__row-actions-batch-delete,
+	.files-list__row-actions-batch-cancel_select {
+		display: none;
+	}
 }
 
 #body-user,

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1427,8 +1427,7 @@ table.files-filestable {
 				}
 			}
 
-			// Pending share rows: disable name link interaction to prevent opening the file
-			// and navigating away from the pending shares view
+			// Hide sharing-popup and actions menu for pending share rows
 			tbody tr:has(.files-list__row-action-accept-share) {
 				td.files-list__row-actions {
 					.action-items {

--- a/css/components/ncactions.scss
+++ b/css/components/ncactions.scss
@@ -13,6 +13,11 @@
 	}
 }
 
+// Hide text label on action menu toggle buttons that show the three-dot icon
+.action-item__menutoggle:has(.dots-horizontal-icon) .button-vue__text {
+	display: none;
+}
+
 #body-user,
 #body-settings,
 #body-public {

--- a/src/nmcfiles.ts
+++ b/src/nmcfiles.ts
@@ -119,9 +119,12 @@ if (document.readyState === 'loading') {
 	setupLinkBubbleFix()
 }
 
+function isPendingShareRow(row: Element): boolean {
+	return !!row.querySelector('.files-list__row-action-accept-share')
+}
+
 /**
  * Prevent row clicks and sidebar opening on pending share rows.
- * Pending share rows are identified by the presence of the accept-share action button.
  */
 function blockPendingShareRowClick(row: HTMLElement): void {
 	if (row.dataset.pendingShareBlocked === 'true') return
@@ -134,12 +137,9 @@ function blockPendingShareRowClick(row: HTMLElement): void {
 		}, true)
 	}
 
-	// Also block row-level clicks (opens sidebar) on non-interactive cells
 	row.addEventListener('click', (event: MouseEvent) => {
 		const target = event.target as HTMLElement
-		const isCheckbox = target.closest('.files-list__row-checkbox')
-		const isActionButton = target.closest('.files-list__row-actions')
-		if (!isCheckbox && !isActionButton) {
+		if (!target.closest('.files-list__row-checkbox') && !target.closest('.files-list__row-actions')) {
 			event.preventDefault()
 			event.stopPropagation()
 		}
@@ -148,36 +148,77 @@ function blockPendingShareRowClick(row: HTMLElement): void {
 	row.dataset.pendingShareBlocked = 'true'
 }
 
-function setupPendingShareRowClickBlock(): void {
-	const observer = new MutationObserver((mutations: MutationRecord[]) => {
-		for (const mutation of mutations) {
-			for (const node of Array.from(mutation.addedNodes)) {
-				if (!(node instanceof Element)) continue
-				const rows: HTMLElement[] = node.matches('tr[data-cy-files-list-row]')
-					? [node as HTMLElement]
-					: Array.from(node.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]'))
-				for (const row of rows) {
-					if (row.querySelector('.files-list__row-action-accept-share')) {
-						blockPendingShareRowClick(row)
-					}
-				}
-			}
-		}
-	})
-	observer.observe(document.body, { childList: true, subtree: true })
+/**
+ * Filter menu to show only Accept/Reject share if it belongs to a pending share row.
+ */
+function filterPendingSharePopper(popper: Element): void {
+	const menu = popper.querySelector<HTMLElement>('ul[role="menu"]')
+	if (!menu || !menu.querySelector('.files-list__row-action-accept-share')) return
 
-	// Handle rows already present in the DOM
-	document.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]').forEach(row => {
-		if (row.querySelector('.files-list__row-action-accept-share')) {
-			blockPendingShareRowClick(row)
-		}
+	menu.querySelectorAll<HTMLElement>('li.action, li.action-separator').forEach(item => {
+		const keep = item.classList.contains('files-list__row-action-accept-share')
+			|| item.classList.contains('files-list__row-action-reject-share')
+		item.style.display = keep ? '' : 'none'
 	})
 }
 
+/**
+ * Set up all pending share behaviours: row click blocking and popper menu filtering.
+ * A single MutationObserver handles both DOM concerns.
+ */
+function setupPendingShare(): void {
+	// Handle rows already in the DOM on init
+	document.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]').forEach(row => {
+		if (isPendingShareRow(row)) blockPendingShareRowClick(row)
+	})
+
+	// Single observer: watches for new rows (childList) and popper visibility changes (attributes)
+	const observer = new MutationObserver((mutations: MutationRecord[]) => {
+		for (const mutation of mutations) {
+			if (mutation.type === 'childList') {
+				for (const node of Array.from(mutation.addedNodes)) {
+					if (!(node instanceof Element)) continue
+					const rows = node.matches('tr[data-cy-files-list-row]')
+						? [node as HTMLElement]
+						: Array.from(node.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]'))
+					for (const row of rows) {
+						if (isPendingShareRow(row)) blockPendingShareRowClick(row)
+					}
+				}
+			} else if (
+				mutation.type === 'attributes'
+				&& mutation.target instanceof Element
+				&& mutation.target.classList.contains('v-popper__popper')
+				&& mutation.target.classList.contains('v-popper__popper--shown')
+			) {
+				requestAnimationFrame(() => filterPendingSharePopper(mutation.target as Element))
+			}
+		}
+	})
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: ['class'],
+	})
+
+	// Click capture: retry across frames until the popper is open
+	document.addEventListener('click', (event: MouseEvent) => {
+		if (!(event.target as Element).closest('button.action-item__menutoggle')) return
+
+		const tryFilter = (remaining: number): void => {
+			const popper = document.querySelector('.v-popper__popper.v-popper__popper--shown')
+			if (popper) { filterPendingSharePopper(popper); return }
+			if (remaining > 0) requestAnimationFrame(() => tryFilter(remaining - 1))
+		}
+		requestAnimationFrame(() => tryFilter(10))
+	}, true)
+}
+
 if (document.readyState === 'loading') {
-	document.addEventListener('DOMContentLoaded', setupPendingShareRowClickBlock)
+	document.addEventListener('DOMContentLoaded', setupPendingShare)
 } else {
-	setupPendingShareRowClickBlock()
+	setupPendingShare()
 }
 
 window.addEventListener('DOMContentLoaded', function() {

--- a/src/nmcfiles.ts
+++ b/src/nmcfiles.ts
@@ -119,8 +119,14 @@ if (document.readyState === 'loading') {
 	setupLinkBubbleFix()
 }
 
-function isPendingShareRow(row: Element): boolean {
-	return !!row.querySelector('.files-list__row-action-accept-share')
+const PENDING_SHARES_BODY_CLASS = 'nmc-pendingshares-view'
+
+function isPendingSharesPage(): boolean {
+	return window.location.pathname.includes('/pendingshares')
+}
+
+function syncPendingSharesBodyClass(): void {
+	document.body.classList.toggle(PENDING_SHARES_BODY_CLASS, isPendingSharesPage())
 }
 
 /**
@@ -128,14 +134,6 @@ function isPendingShareRow(row: Element): boolean {
  */
 function blockPendingShareRowClick(row: HTMLElement): void {
 	if (row.dataset.pendingShareBlocked === 'true') return
-
-	const nameLink = row.querySelector<HTMLElement>('.files-list__row-name-link')
-	if (nameLink) {
-		nameLink.addEventListener('click', (event: MouseEvent) => {
-			event.preventDefault()
-			event.stopPropagation()
-		}, true)
-	}
 
 	row.addEventListener('click', (event: MouseEvent) => {
 		const target = event.target as HTMLElement
@@ -167,22 +165,29 @@ function filterPendingSharePopper(popper: Element): void {
  * A single MutationObserver handles both DOM concerns.
  */
 function setupPendingShare(): void {
+	// Sync body class on init and on SPA navigation
+	syncPendingSharesBodyClass()
+	window.addEventListener('popstate', syncPendingSharesBodyClass)
+
 	// Handle rows already in the DOM on init
-	document.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]').forEach(row => {
-		if (isPendingShareRow(row)) blockPendingShareRowClick(row)
-	})
+	if (isPendingSharesPage()) {
+		document.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]').forEach(row => {
+			blockPendingShareRowClick(row)
+		})
+	}
 
 	// Single observer: watches for new rows (childList) and popper visibility changes (attributes)
 	const observer = new MutationObserver((mutations: MutationRecord[]) => {
 		for (const mutation of mutations) {
 			if (mutation.type === 'childList') {
+				if (!isPendingSharesPage()) continue
 				for (const node of Array.from(mutation.addedNodes)) {
 					if (!(node instanceof Element)) continue
 					const rows = node.matches('tr[data-cy-files-list-row]')
 						? [node as HTMLElement]
 						: Array.from(node.querySelectorAll<HTMLElement>('tr[data-cy-files-list-row]'))
 					for (const row of rows) {
-						if (isPendingShareRow(row)) blockPendingShareRowClick(row)
+						blockPendingShareRowClick(row)
 					}
 				}
 			} else if (

--- a/src/nmcfiles.ts
+++ b/src/nmcfiles.ts
@@ -161,13 +161,27 @@ function filterPendingSharePopper(popper: Element): void {
 }
 
 /**
+ * Patch history.pushState and history.replaceState to dispatch a custom
+ * 'locationchange' event, enabling detection of SPA navigation.
+ */
+function patchHistoryForNavigation(): void {
+	const dispatch = () => window.dispatchEvent(new Event('locationchange'))
+	const originalPush = history.pushState.bind(history)
+	const originalReplace = history.replaceState.bind(history)
+	history.pushState = (...args) => { originalPush(...args); dispatch() }
+	history.replaceState = (...args) => { originalReplace(...args); dispatch() }
+}
+
+/**
  * Set up all pending share behaviours: row click blocking and popper menu filtering.
  * A single MutationObserver handles both DOM concerns.
  */
 function setupPendingShare(): void {
-	// Sync body class on init and on SPA navigation
+	// Sync body class on init and on SPA navigation (pushState + popstate)
+	patchHistoryForNavigation()
 	syncPendingSharesBodyClass()
 	window.addEventListener('popstate', syncPendingSharesBodyClass)
+	window.addEventListener('locationchange', syncPendingSharesBodyClass)
 
 	// Handle rows already in the DOM on init
 	if (isPendingSharesPage()) {


### PR DESCRIPTION
Hide all actions except Accept share and Reject share in the overflow popper menu for pending share rows. The popper is teleported to body so CSS :has() cannot reach it; a click capture listener with rAF retry and a MutationObserver handle the filtering.

Refactored pending share setup into a single setupPendingShare function with one shared MutationObserver for both row blocking and popper filtering.

<img width="697" height="417" alt="Screenshot 2026-04-09 at 16 23 27" src="https://github.com/user-attachments/assets/328ff156-9f1e-4f35-883e-92a98fe07465" />
<img width="695" height="522" alt="Screenshot 2026-04-09 at 16 23 35" src="https://github.com/user-attachments/assets/91f6a90c-9015-41bf-94b3-ebdd43f9aa2d" />
<img width="692" height="662" alt="Screenshot 2026-04-09 at 16 23 48" src="https://github.com/user-attachments/assets/76b8b68d-bf8e-4255-a69b-c5fc531af4b1" />
