### PR TITLE
icons removed from mobile view

### DIFF
--- a/css/apps/photos.scss
+++ b/css/apps/photos.scss
@@ -428,8 +428,13 @@
 					justify-content: space-between;
 
 					.actions-right{
-						display: flex;
-						gap: 30px;
+						display: grid;
+						gap: 0 30px;
+						grid: auto-flow/3fr 3fr;
+
+						@media screen and (max-width: $breakpoint-mobile) {
+							display: none;
+						}
 					}
 				}
 


### PR DESCRIPTION
Photos & Videos – Firefox / Safari
The “View info” and “Delete” icons are removed in mobile view once hovered or marked checked. This resolves the overlapping issue of icons on small screens.