### PR TITLE
nmc/5963-hide-footer-in-text-editor

### DIFF
--- a/css/apps/viewer.scss
+++ b/css/apps/viewer.scss
@@ -18,7 +18,6 @@
         height: calc(100vh - var(--header-height) - var(--footer-height));
     }
 
-    
     .modal-header {
 
         &__name {

--- a/css/apps/viewer.scss
+++ b/css/apps/viewer.scss
@@ -17,7 +17,7 @@
     .viewer__content {
         height: calc(100vh - var(--header-height) - var(--footer-height));
     }
-
+    
     .modal-header {
 
         &__name {

--- a/css/apps/viewer.scss
+++ b/css/apps/viewer.scss
@@ -17,6 +17,14 @@
     .viewer__content {
         height: calc(100vh - var(--header-height) - var(--footer-height));
     }
+
+    &[data-handler="text"] {
+        --footer-height: 0px;
+
+        .viewer__footer {
+            display: none;
+        }
+    }
     
     .modal-header {
 

--- a/css/apps/viewer.scss
+++ b/css/apps/viewer.scss
@@ -18,13 +18,6 @@
         height: calc(100vh - var(--header-height) - var(--footer-height));
     }
 
-    &[data-handler="text"] {
-        --footer-height: 0px;
-
-        .viewer__footer {
-            display: none;
-        }
-    }
     
     .modal-header {
 

--- a/css/layouts/footer.scss
+++ b/css/layouts/footer.scss
@@ -18,6 +18,10 @@ footer {
     --footer-font: var(--default-font-style-bold);
 }
 
+body:has(#viewer[data-handler]) #telekom-minimal-footer {
+    display: none;
+}
+
 footer[role="contentinfo"] {
     background-color: var(--color-main-background);
     display: block;


### PR DESCRIPTION
The footer was already hidden in the app but appears to still be visible on mobile web view. Adding explicit CSS to hide the footer and reset its height variable to 0 when data-handler="text" is active, to test and confirm the fix.