### PR TITLE
nmc/5424-pending-share-remove-three-dot-menu-and-add-to-favorite-in-batch-action-bar

### DIFF
--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1563,8 +1563,15 @@ body.nmc-pendingshares-view {
 	.files-list__row-actions-batch-move-copy,
 	.files-list__row-actions-batch-download,
 	.files-list__row-actions-batch-delete,
-	.files-list__row-actions-batch-cancel_select {
+	.files-list__row-actions-batch-cancel_select,
+	.files-list__row-actions-batch-favorite {
 		display: none;
+	}
+
+	@media screen and (min-width: $breakpoint-mobile) {
+		.action-items > div.action-item {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Hide the add to favorites button and the three dot actions menu from the batch action toolbar in the pending shares view. The three dot menu is only hidden on full-width screens and remains visible on smaller screens.