### PR TITLE
nmc/6050-sharing-popup-notification-success-page-ui-for-long-file-folder-name

### DIFF
--- a/css/apps/sharing.scss
+++ b/css/apps/sharing.scss
@@ -397,6 +397,7 @@ body .icon-upload-to-cloud, body .icon-upload-to-cloud-dark {
 .sharingPopup__success {
 	padding: 1rem;
 	display: grid;
+	overflow: hidden;
 
 	.check-circle-outline-icon {
 		background-image: var(--icon-popup-success-success);
@@ -416,11 +417,17 @@ body .icon-upload-to-cloud, body .icon-upload-to-cloud-dark {
 		text-align: center;
 		font-size: 24px;
 		margin-bottom: 1rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.recipients {
 		text-align: center;
 		color: var(--color-text-maxcontrast);
 		margin-bottom: 3rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 }

--- a/css/layouts/header.scss
+++ b/css/layouts/header.scss
@@ -252,9 +252,30 @@ header {
 				}
 
 				.notification-subject {
+					overflow: hidden;
+					min-width: 0;
 
 					.image {
 						display: none;
+					}
+
+					.rich-text--wrapper {
+						overflow: hidden;
+						width: 100%;
+						min-width: 0;
+
+						> div {
+							overflow: hidden;
+						}
+					}
+
+					strong.rich-text--component {
+						display: inline-block;
+						max-width: 100%;
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
+						vertical-align: bottom;
 					}
 				}
 


### PR DESCRIPTION
fix: truncate long file/folder names with ellipsis in sharing and notification UI