### PR TITLE
nmc/5798-files-sharing-expiration-date-field-size-is-too-big

### DIFF
--- a/css/apps/files-sharing.scss
+++ b/css/apps/files-sharing.scss
@@ -66,6 +66,10 @@
 .sharingPopupDetailsView {
 
     #share-date-picker {
+        -webkit-appearance: none;
+        appearance: none;
+        box-sizing: border-box;
+        height: 56px !important;
         color-scheme: var(--nmc-color-sceme);
 
         &::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
The expiration date input (#share-date-picker) in the sharing modal was rendering at 628x59 in Safari while other inputs (label, password) rendered at the correct 582x57 size.

Root cause: Safari enforces a native intrinsic minimum width and height on type="date" inputs when -webkit-appearance is not explicitly reset. This caused the date picker to overflow its container width by ~46px and exceed the intended height by ~3px regardless of the CSS width/height rules in ncfields.scss.

Fix:
- Add -webkit-appearance: none and appearance: none to remove Safari's native date picker chrome, allowing the existing width: calc(100% - 10px) from ncfields.scss to apply correctly
- Add box-sizing: border-box to ensure padding is absorbed within the declared dimensions
- Add height: 56px !important scoped directly on #share-date-picker to explicitly override Safari's native input height

Affects: .sharingTabDetailsView and .sharingPopupDetailsView