### PR TITLE
nmc/5917-android-add-folder-popup-does-not-close-after-tapping-X-button-in-Photo-Settings

### DIFF
--- a/css/layouts/modal.scss
+++ b/css/layouts/modal.scss
@@ -59,8 +59,7 @@
                     touch-action: manipulation;
                 }
 
-                &__content, .dialog__content {
-                    overflow-y: auto;
+                &__content {
                     padding-inline: 0;
 
                     .button-vue--vue-secondary {
@@ -124,6 +123,11 @@
                     .app-settings-section__name, .app-settings-section__content, .setting-section-subline, .photos-locations {
                         margin-bottom: 0.5rem;
                     }
+                }
+
+                .dialog__content {
+                    overflow-y: auto;
+                    padding-inline: 0;
                 }
 
                 &:has(.modal__content--exif) {


### PR DESCRIPTION
The modal-container__content element was receiving overflow-y: auto via the NMC theme override, turning it into a scroll container. On Android Chrome, this scroll container intercepts touch events in its rendered bounds — which overlaps with the absolutely-positioned close button (top: 0.5rem, right: 0.5rem). As a result, tapping the X button had no effect on Android tablets (tested on Samsung Galaxy Tab A8 / Android 14 and Lenovo Tab M10 / Android 12).

NcDialog intentionally sets modal-container__content to overflow: hidden and handles scrolling one level deeper at dialog__content. The NMC override was defeating this by making the outer container a touch scroll target.

Fix: separate the combined &__content, .dialog__content selector so that overflow-y: auto only applies to .dialog__content (where scrolling belongs), leaving modal-container__content without an overflow override. NcDialog's own scoped CSS (overflow: hidden) now applies correctly, eliminating the touch event interception on Android.