### PR TITLE
Nmc/6235 android files change loading bar position

### DIFF
--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -485,8 +485,34 @@ table.files-filestable {
 
 			.upload-picker__cancel {
 				z-index: 1;
-				position: absolute;
-				left: 3rem; 
+				position: relative;
+				left: -148px;
+				float: left;
+				padding: 0;
+				background: var(--color-main-background);
+			}
+			// .upload-picker__cancel {
+			// 	z-index: 1;
+			// 	position: absolute;
+			// 	left: 3rem; 
+			// }
+
+			.files-list__header-upload-button {
+				padding-left: 2rem;
+				background-color: var(--color-main-background);
+				z-index: 1;
+			}
+		}
+
+		@media (min-width: $breakpoint-mobile-small) and (max-width: $breakpoint-mobile-medium) {
+			.upload-picker__progress {
+				width: 310px;
+				max-width: 320px;
+				margin-right: 3rem;
+				margin-top: 23px;
+				padding: 1rem 0 1rem 1rem;
+				background: var(--color-main-background);
+				z-index: 1;
 			}
 		}
 		

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -463,7 +463,7 @@ table.files-filestable {
 		}
 
 		.upload-picker__progress {
-			width: 320px;
+			width: 300px;
 			max-width: 320px;
 			
 			//Adjusting the position of the progress bar to align with the secondary loader
@@ -491,11 +491,6 @@ table.files-filestable {
 				padding: 0;
 				background: var(--color-main-background);
 			}
-			// .upload-picker__cancel {
-			// 	z-index: 1;
-			// 	position: absolute;
-			// 	left: 3rem; 
-			// }
 
 			.files-list__header-upload-button {
 				padding-left: 2rem;
@@ -506,13 +501,19 @@ table.files-filestable {
 
 		@media (min-width: $breakpoint-mobile-small) and (max-width: $breakpoint-mobile-medium) {
 			.upload-picker__progress {
-				width: 310px;
+				width: 300px;
 				max-width: 320px;
 				margin-right: 3rem;
 				margin-top: 23px;
 				padding: 1rem 0 1rem 1rem;
 				background: var(--color-main-background);
 				z-index: 1;
+			}
+		}
+		@media (min-width: $breakpoint-mobile-medium) and (max-width: $breakpoint-mobile) { 
+			.upload-picker__progress {
+				margin-right: 2rem;
+				width: 260px;
 			}
 		}
 		

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -470,7 +470,30 @@ table.files-filestable {
 			margin-right: 6rem;
     		margin-top: 23px;
 		}
+
+		// Responsive adjustment for upload progress bar
+		@media screen and (max-width: $breakpoint-mobile-small) {
+			.upload-picker__progress {
+				width: 140px !important;
+				max-width: 320px;
+				margin-right: 4rem !important;
+				padding: 1rem;
+				background: var(--color-main-background);
+				z-index: 1;
+				position: absolute;
+			}
+
+			.upload-picker__cancel {
+				z-index: 1;
+				position: absolute;
+				left: 3rem; 
+			}
+		}
 		
+		.files-list__breadcrumbs--with-progress {
+			flex-direction: row !important;
+		}
+
 		.files-list__refresh-icon {
 			position: absolute;
 			right: 13rem;

--- a/css/components/ncbreadcrumb.scss
+++ b/css/components/ncbreadcrumb.scss
@@ -6,6 +6,12 @@
 
 	nav {
 		height: 44px;
+		margin: 0px 10px;
+		@media (min-width: $breakpoint-mobile-medium) and (max-width: $breakpoint-mobile) { 
+			nav {
+				flex-shrink: 0;
+			}
+		}
 
 		ul.breadcrumb__crumbs {
 			// Display root as "Start" text


### PR DESCRIPTION
Adjusted responsive styles for `<UploadPicker>` and related elements. Updated progress bar width, margins, and positioning across mobile breakpoints to improve alignment and readability. Also refined cancel button and upload button styles for consistent background and z-index handling. Added flex-direction: row override for breadcrumbs when progress is visible.