### PR TITLE
nmc/5802-search-term-randomly-disappearing

### DIFF
--- a/css/components/search.scss
+++ b/css/components/search.scss
@@ -100,7 +100,8 @@
                 }
 
                 &:hover label.input-field__label,
-                &:focus-within label.input-field__label {
+                &:focus-within label.input-field__label,
+                &:has(.input-field__input:not(:placeholder-shown)) label.input-field__label {
                     top: 30%;
                     left: 0;
                     transform: translateY(-50%);
@@ -109,6 +110,7 @@
                 }
 
                 .input-field__input {
+                    &:not(:placeholder-shown),
                     &:hover,
                     &:focus,
                     &:active {


### PR DESCRIPTION
When the user typed a search term and clicked outside the input, the floating label snapped back to center and covered the typed text, making it appear as if the value had disappeared. Added :has(:not(:placeholder-shown)) so the label stays floated and padding-top is maintained whenever the input contains a value, regardless of focus state.