### PR TITLE
Nmc/5782 web files black and white overlapping borders shown after folder renaming

### DIFF
--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1198,11 +1198,15 @@ table.files-filestable {
 							min-height: 36px;
 							min-width: 0;
 							margin: 0;
-							padding: 0 1rem;
+							box-shadow: none !important;
 
 							.files-list__row-name-text {
 								margin: 0;
-								padding: 0;
+								padding: 3px;
+
+								span {
+									outline: none;
+								}
 							}
 						}
 

--- a/css/apps/files.scss
+++ b/css/apps/files.scss
@@ -1198,6 +1198,7 @@ table.files-filestable {
 							min-height: 36px;
 							min-width: 0;
 							margin: 0;
+							padding: 0 1rem;
 							box-shadow: none !important;
 
 							.files-list__row-name-text {


### PR DESCRIPTION
This PR addresses the issue where borders appeared around the folder name text and icons after renaming and hovering:

- Removed default box-shadow and outline styles from `.files-list__row-name-link` and its child elements.
- Ensured folder name text (`.files-list__row-name-text`) render focus outlines without touching text.
- Maintained proper alignment and spacing with flex layout, padding, and min-height adjustments.