### PR TITLE
nmc/5775-Trash-bin-Text-x-selected-still-shown-after-clearing-the-bin

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -100,5 +100,6 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		\OCP\Util::addScript("nmctheme", "nmctheme-searchfavorites", "core");
 		\OCP\Util::addScript("nmctheme", "nmctheme-filessettings", "files");
 		\OCP\Util::addScript("nmctheme", "nmctheme-filelistplugin", "files");
+		\OCP\Util::addScript("nmctheme", "nmctheme-trashbinfix", "files");
 	}
 }

--- a/src/js/trashbinfix.js
+++ b/src/js/trashbinfix.js
@@ -1,0 +1,28 @@
+(function() {
+	const clearSelection = () => {
+		document.querySelector('[data-cy-files-list-selection-action="cancel_select"]')?.click()
+	}
+
+	// Nextcloud does not reset the Vue selection store after trashbin delete/restore.
+	// We watch the table's class: when it gets files-list__table--hidden (empty state),
+	// we click Cancel to clear the stale selection.
+	// Note: window.fetch interception does not work here because the @nextcloud/webdav
+	// library captures the fetch reference at module init time before our script runs.
+	const watchTableState = () => {
+		const table = document.querySelector('.files-list__table')
+		if (!table) return
+
+		const observer = new MutationObserver(() => {
+			if (table.classList.contains('files-list__table--hidden')) {
+				clearSelection()
+			}
+		})
+		observer.observe(table, { attributes: true, attributeFilter: ['class'] })
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', () => setTimeout(watchTableState, 500))
+	} else {
+		setTimeout(watchTableState, 500)
+	}
+})()

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -8,6 +8,7 @@ webpackConfig.entry = {
 	...webpackConfig.entry,
 	filessettings: path.join(__dirname, 'src', 'js', 'filessettings.js'),
 	filelistplugin: path.join(__dirname, 'src', 'js', 'filelistplugin.js'),
+	trashbinfix: path.join(__dirname, 'src', 'js', 'trashbinfix.js'),
 	skipactions: path.join(__dirname, 'src', 'js', 'skipactions.js'),
 	searchfavorites: path.join(__dirname, 'src', 'js', 'searchfavorites.js'),
 	conflictdialog: path.join(__dirname, 'src', 'js', 'conflictdialog.js'),


### PR DESCRIPTION
After permanently deleting or restoring files from the trashbin, the "N selected" overlay persisted until page reload. This adds a MutationObserver that watches for the table's empty state class and programmatically clicks Cancel to reset the Vue selection store.