### PR TITLE
nmc/5903-favorites-rename-option-missing

### DIFF
--- a/src/nmcfiles.ts
+++ b/src/nmcfiles.ts
@@ -50,6 +50,25 @@ registerFileAction(fileAction)
 
 const FileActions = getFileActions()
 
+const renameAction = FileActions.find(action => action.id === 'rename')
+
+if (renameAction?.enabled) {
+	const originalEnabled = renameAction.enabled
+
+	// Relies on `_action` being a plain field on FileAction (@nextcloud/files
+	// internal detail) - re-verify on @nextcloud/files upgrades.
+	;(renameAction as unknown as { _action: { enabled: typeof originalEnabled } })._action.enabled = (nodes: Node[], view: View) => {
+		if (view.id !== 'favorites') {
+			return originalEnabled(nodes, view)
+		}
+
+		return nodes.every(node =>
+			Boolean(node.permissions & Permission.DELETE)
+			&& Boolean(node.permissions & Permission.UPDATE),
+		)
+	}
+}
+
 const sharingStatusAction = FileActions.find(action => action.id === 'sharing-status')
 
 if (sharingStatusAction) {


### PR DESCRIPTION
The core files app hides "Rename" for every item in the Favorites view because its enabled() check requires the real parent folder to have CREATE permission. Favorites is a flattened list aggregating items from many different folders, so no single real parent is resolvable, and the check always fails there.

Patch the rename action's enabled() at runtime, scoped to the favorites view only, to fall back to the node's own DELETE + UPDATE permission bits instead of the parent folder's permissions. All other views keep the original, unmodified behavior.