### PR TITLE
fix: unified search results cut off on Android browser

### DIFF
--- a/css/components/search.scss
+++ b/css/components/search.scss
@@ -81,7 +81,7 @@
 #unified-search .unified-search-modal {
     
     .unified-search-modal__content {
-        --dialog-height: min(65vh, 700px);
+        --dialog-height: min(65dvh, 700px);
 
         .unified-search-modal__header {
             align-items: center;

--- a/css/layouts/modal.scss
+++ b/css/layouts/modal.scss
@@ -34,7 +34,7 @@
                 .modal-container {
                     box-shadow: none;
                     padding: 0;
-                    max-height: 100vh;
+                    max-height: 100dvh;
                 }
             }
 
@@ -48,7 +48,7 @@
                 box-shadow: unset;
                 box-sizing: border-box;
                 padding: 1.5rem;
-                max-height: 80vh;
+                max-height: 80dvh;
                 max-width: 100vw;
                 display: flex;
                 flex-direction: column;
@@ -177,8 +177,6 @@
         .modal-container {
             @media screen and (max-width: $breakpoint-mobile-small) {
                 margin: 1rem;
-                flex-direction: unset !important;
-                overflow: auto;
             }
 
             .dialog__name {


### PR DESCRIPTION
On Android Chrome, vh units resolve against the large viewport (address bar hidden), so the modal and dialog content were sized taller than the actually visible area whenever the address bar was shown. This pushed the results list, including the "Load more results" footer, below the fold and made it unreachable when a search matched many files.

Switch the modal and unified search dialog height constraints from vh to dvh so they track the real visible viewport as the address bar shows and hides. Also remove a mobile-only override that reset the modal container's flex-direction back to row and let it scroll itself, which collapsed the vertical layout the dialog relies on for its sticky header and scrollable results region.