### PR TITLE
nmc/5785-date-inside-the-manage-access-screen-is-cut

### DIFF
--- a/css/apps/sharing.scss
+++ b/css/apps/sharing.scss
@@ -16,6 +16,13 @@
 			padding: 0.5rem 1rem 1.5rem;
 
 			.app-sidebar-header__subname {
+				white-space: normal;
+				overflow: visible;
+				text-overflow: unset;
+
+				.sidebar__subname {
+					flex-wrap: wrap;
+				}
 
 				.sidebar__subname-separator:not(:has(~ .sidebar__subname-separator)), 
 				span:has(+ .user-bubble__wrapper),


### PR DESCRIPTION
The subname line in the app sidebar header used nowrap/ellipsis on a flex container, so the ellipsis never rendered and the date was hard-clipped on narrow viewports. Allow the metadata row to wrap instead so the full date stays visible.